### PR TITLE
fix(#4): 호환성 문제로 인한 platforms 부분 변경

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -59,7 +59,7 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile-dev
           push: true
-          platforms: linux/arm64
+          platforms: linux/amd64
           tags: ${{ env.DOCKER_HUB_REPOSITORY }}:latest
 
   backend-docker-pull-and-run:


### PR DESCRIPTION
ncp 서버의 os와 docker 에서 build된 파일의 호환성 문제로 인해 발생한 exec /usr/java/openjdk-17/bin/java: exec format error를 해결하기 위해 수정