### PR TITLE
fix: 계획하기(plans) 반환 값에 예약한 일자와 시간까지 포함해서 전달하도록 수정

### DIFF
--- a/src/main/java/com/sideproject/hororok/cafe/dto/CreatePlanDto.java
+++ b/src/main/java/com/sideproject/hororok/cafe/dto/CreatePlanDto.java
@@ -18,8 +18,8 @@ public class CreatePlanDto {
     private final PlanMatchType matchType;
     private final String locationName;
     private final Integer minutes;
+    private final String visitDateTime;
     private final CategoryKeywords categoryKeywords;
-    private final List<Cafe> cafe;
     private final List<Cafe> recommendCafes;
     private final List<Cafe> matchCafes;
     private final List<Cafe> similarCafes;
@@ -27,12 +27,13 @@ public class CreatePlanDto {
 
     //맞춘 경우
     public static CreatePlanDto of(PlanMatchType matchType, CreatePlanSearchCond searchCond,
-                                   List<Cafe> matchCafes, List<Cafe> similarCafes) {
+                                   String visitDateTime, List<Cafe> matchCafes, List<Cafe> similarCafes) {
 
         return CreatePlanDto.builder()
                 .matchType(matchType)
                 .locationName(searchCond.getLocationName())
                 .minutes(searchCond.getMinutes())
+                .visitDateTime(visitDateTime)
                 .categoryKeywords(searchCond.getCategoryKeywords())
                 .similarCafes(similarCafes)
                 .matchCafes(matchCafes)

--- a/src/main/java/com/sideproject/hororok/cafe/service/CafePlanService.java
+++ b/src/main/java/com/sideproject/hororok/cafe/service/CafePlanService.java
@@ -12,6 +12,7 @@ import com.sideproject.hororok.operationHours.repository.OperationHourRepository
 import com.sideproject.hororok.review.service.ReviewService;
 import com.sideproject.hororok.utils.calculator.GeometricUtils;
 import com.sideproject.hororok.plan.enums.PlanMatchType;
+import com.sideproject.hororok.utils.converter.FormatConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -67,7 +68,9 @@ public class CafePlanService {
             orderByDistanceAndStarRating(allMatchAtKeywordCafes, searchCond.getLatitude(), searchCond.getLongitude());
             keywordFilteredCafes.removeAll(allMatchAtKeywordCafes);
             matchType = PlanMatchType.MATCH;
-            return CreatePlanDto.of(matchType, searchCond, allMatchAtKeywordCafes, keywordFilteredCafes);
+
+            return CreatePlanDto.of(matchType, searchCond, FormatConverter.convertVisitDateTime(searchCond),
+                    allMatchAtKeywordCafes, keywordFilteredCafes);
         }
 
         matchType = PlanMatchType.SIMILAR;
@@ -212,4 +215,6 @@ public class CafePlanService {
 
         return distanceFilteredCafe;
     }
+
+
 }

--- a/src/main/java/com/sideproject/hororok/utils/converter/FormatConverter.java
+++ b/src/main/java/com/sideproject/hororok/utils/converter/FormatConverter.java
@@ -4,6 +4,8 @@ import com.sideproject.hororok.cafe.cond.CreatePlanSearchCond;
 
 import java.text.NumberFormat;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 public class FormatConverter {
 
@@ -56,6 +58,17 @@ public class FormatConverter {
             default:
                 throw new IllegalArgumentException("유효하지 않은 요일입니다: " + day);
         }
+    }
+
+
+    public static String convertVisitDateTime(CreatePlanSearchCond searchCond) {
+
+        LocalDate date = LocalDate.parse(searchCond.getDate());
+        LocalTime startTime = searchCond.getStartTime();
+
+        return date.getMonthValue()+"월 " + date.getDayOfMonth()+"일 " +
+                getKoreanDayOfWeek(date.getDayOfWeek()) + "요일 " +
+                startTime.getHour() + "시 " + startTime.getMinute()+"분";
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈



## 📝작업 내용

> 계획하기(api/plans) 호출 시에 반환되는 값 중 계획자가 방문하려는 날짜와 시간 정보까지 포함해서 전달하도록 변경
> visitDateTime String 변수에 "4월 3일 화요일 15시 30분" 처럼 완전한 문장을 만들어서 전달할 수 있도록 제작

