### PR TITLE
feat(#78): 폴더 내 즐겨찾기의 개수를 구하기 위해 Repository와 조회기능 구현

### DIFF
--- a/src/main/java/com/sideproject/hororok/favorite/application/FavoriteFolderService.java
+++ b/src/main/java/com/sideproject/hororok/favorite/application/FavoriteFolderService.java
@@ -3,6 +3,7 @@ package com.sideproject.hororok.favorite.application;
 import com.sideproject.hororok.auth.dto.LoginMember;
 import com.sideproject.hororok.favorite.domain.FavoriteFolder;
 import com.sideproject.hororok.favorite.domain.FavoriteFolderRepository;
+import com.sideproject.hororok.favorite.domain.FavoriteRepository;
 import com.sideproject.hororok.favorite.dto.FavoriteFolderDto;
 import com.sideproject.hororok.favorite.dto.response.MyPlaceResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,30 +19,25 @@ import java.util.stream.Collectors;
 public class FavoriteFolderService {
 
     private final FavoriteFolderRepository favoriteFolderRepository;
+    private final FavoriteRepository favoriteRepository;
 
     public MyPlaceResponse myPlace(LoginMember loginMember) {
 
         Long memberId = loginMember.getId();
-        Long count = countByMemberId(memberId);
+        Long count = favoriteFolderRepository.countByMemberId(memberId);
 
         List<FavoriteFolderDto> folders =
-                mapToFavoriteFolderDtoList(findByMemberId(memberId));
+                mapToFavoriteFolderDtoList(favoriteFolderRepository.findByMemberId(memberId));
 
         return new MyPlaceResponse(count, folders);
-    }
-
-    public Long countByMemberId(Long memberId) {
-        return favoriteFolderRepository.countByMemberId(memberId);
-    }
-
-    public List<FavoriteFolder> findByMemberId(Long memberId){
-        return favoriteFolderRepository.findByMemberId(memberId);
     }
 
     public List<FavoriteFolderDto> mapToFavoriteFolderDtoList(List<FavoriteFolder> folders) {
 
         return folders.stream()
-                .map(folder -> FavoriteFolderDto.from(folder))
+                .map(folder ->
+                        FavoriteFolderDto
+                                .of(folder, favoriteRepository.countByFavoriteFolderId(folder.getId())))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/sideproject/hororok/favorite/domain/Favorite.java
+++ b/src/main/java/com/sideproject/hororok/favorite/domain/Favorite.java
@@ -25,4 +25,12 @@ public class Favorite {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "bookmark_folders_id")
     private FavoriteFolder favoriteFolder;
+
+    protected Favorite() {
+    }
+
+    public Favorite(final Cafe cafe, final FavoriteFolder favoriteFolder) {
+        this.cafe = cafe;
+        this.favoriteFolder = favoriteFolder;
+    }
 }

--- a/src/main/java/com/sideproject/hororok/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/com/sideproject/hororok/favorite/domain/FavoriteRepository.java
@@ -1,0 +1,9 @@
+package com.sideproject.hororok.favorite.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    Long countByFavoriteFolderId(Long favoriteFolderId);
+}

--- a/src/main/java/com/sideproject/hororok/favorite/dto/FavoriteFolderDto.java
+++ b/src/main/java/com/sideproject/hororok/favorite/dto/FavoriteFolderDto.java
@@ -10,23 +10,26 @@ public class FavoriteFolderDto {
     private Long folderId;
     private String name;
     private String color;
+    private Long favoriteCount;
     private boolean isVisible;
 
-    public static FavoriteFolderDto from(FavoriteFolder favoriteFolder) {
+    public static FavoriteFolderDto of(final FavoriteFolder favoriteFolder, final Long favoriteCount) {
         return FavoriteFolderDto.builder()
                 .folderId(favoriteFolder.getId())
                 .name(favoriteFolder.getName())
                 .color(favoriteFolder.getColor())
+                .favoriteCount(favoriteCount)
                 .isVisible(favoriteFolder.getIsVisible())
                 .build();
     }
 
-    public static FavoriteFolderDto of(final Long folderId, final String name,
-                                       final String color, final boolean isVisible) {
+    public static FavoriteFolderDto of(final Long folderId, final String name, final String color,
+                                       final boolean isVisible, final Long favoriteCount) {
         return FavoriteFolderDto.builder()
                 .folderId(folderId)
                 .name(name)
                 .color(color)
+                .favoriteCount(favoriteCount)
                 .isVisible(isVisible)
                 .build();
     }

--- a/src/main/java/com/sideproject/hororok/favorite/dto/response/MyPlaceResponse.java
+++ b/src/main/java/com/sideproject/hororok/favorite/dto/response/MyPlaceResponse.java
@@ -12,20 +12,20 @@ import java.util.stream.Collectors;
 @Getter
 public class MyPlaceResponse {
 
-    private Long count;
+    private Long folderCount;
     private List<FavoriteFolderDto> folders;
 
     private MyPlaceResponse() {
     }
 
-    public MyPlaceResponse(final Long count) {
-        this.count = count;
+    public MyPlaceResponse(final Long folderCount) {
+        this.folderCount = folderCount;
         this.folders = new ArrayList<>();
     }
 
-    public MyPlaceResponse(final Long count,
+    public MyPlaceResponse(final Long folderCount,
                            final List<FavoriteFolderDto> folders) {
-        this.count = count;
+        this.folderCount = folderCount;
         this.folders =folders;
     }
 

--- a/src/test/java/com/sideproject/hororok/common/fixtures/CafeFixtures.java
+++ b/src/test/java/com/sideproject/hororok/common/fixtures/CafeFixtures.java
@@ -1,0 +1,29 @@
+package com.sideproject.hororok.common.fixtures;
+
+import com.sideproject.hororok.cafe.domain.Cafe;
+
+import java.math.BigDecimal;
+import java.util.Random;
+
+public class CafeFixtures {
+
+    public static final Long 카페_아이디 = 1L;
+    public static final String 카페_이름 = "카페 이름";
+    public static final String 카페_전화번호 = "000-0000-0000";
+    public static final String 카페_도로명_주소 = "OO시 OO구 OO동";
+    public static final BigDecimal 카페_위도 = getRandomBigDecimal(-90, 90);
+    public static final BigDecimal 카페_경도 = getRandomBigDecimal(-180, 180);
+
+    public static Cafe 카페() {
+        return new Cafe(
+                카페_이름, 카페_전화번호, 카페_도로명_주소, 카페_위도, 카페_경도);
+    }
+
+    private static BigDecimal getRandomBigDecimal(int min, int max) {
+        Random random = new Random();
+        double range = max - min;
+        double scaled = random.nextDouble() * range;
+        double shifted = scaled + min;
+        return BigDecimal.valueOf(shifted);
+    }
+}

--- a/src/test/java/com/sideproject/hororok/common/fixtures/FavoriteFixtures.java
+++ b/src/test/java/com/sideproject/hororok/common/fixtures/FavoriteFixtures.java
@@ -1,0 +1,15 @@
+package com.sideproject.hororok.common.fixtures;
+
+import com.sideproject.hororok.cafe.domain.Cafe;
+import com.sideproject.hororok.favorite.domain.Favorite;
+import com.sideproject.hororok.favorite.domain.FavoriteFolder;
+
+public class FavoriteFixtures {
+
+    public static final Long 폴더_즐겨찾기_개수 = 2L;
+
+
+    public static Favorite 즐겨찾기(final Cafe cafe, final FavoriteFolder favoriteFolder) {
+        return new Favorite(cafe, favoriteFolder);
+    }
+}

--- a/src/test/java/com/sideproject/hororok/common/fixtures/FavoriteFolderFixtures.java
+++ b/src/test/java/com/sideproject/hororok/common/fixtures/FavoriteFolderFixtures.java
@@ -7,15 +7,17 @@ import com.sideproject.hororok.member.domain.Member;
 
 import java.util.List;
 
+import static com.sideproject.hororok.common.fixtures.FavoriteFixtures.폴더_즐겨찾기_개수;
+
 
 public class FavoriteFolderFixtures {
 
-    public static final Long 폴더_있을때_개수 = 2L;
-    public static final Integer 폴더_있을때_리스트_사이즈 = 2;
-    public static final Integer 폴더_있을때_리스트_인덱스1 = 0;
-    public static final Integer 폴더_있을때_리스트_인덱스2 = 1;
-    public static final Long 폴더_있을때_ID_1 = 1L;
-    public static final Long 폴더_있을때_ID_2 = 2L;
+    public static final Long 폴더_개수 = 2L;
+    public static final Integer 폴더_리스트_사이즈 = 2;
+    public static final Integer 폴더_리스트_인덱스1 = 0;
+    public static final Integer 폴더_리스트_인덱스2 = 1;
+    public static final Long 폴더_ID_1 = 1L;
+    public static final Long 폴더_ID_2 = 2L;
 
     /* 폴더1 */
     public static final String 즐겨찾기_폴더_이름1 = "즐겨찾기_폴더_이름1";
@@ -42,7 +44,7 @@ public class FavoriteFolderFixtures {
             final Long folderId, final String name,
             final String color, final Boolean isVisible){
         return FavoriteFolderDto.of(
-                folderId, name, color, isVisible);
+                folderId, name, color, isVisible, 폴더_즐겨찾기_개수);
     }
 
     public static MyPlaceResponse 마이_플레이스_응답(

--- a/src/test/java/com/sideproject/hororok/favorite/application/FavoriteFolderServiceTest.java
+++ b/src/test/java/com/sideproject/hororok/favorite/application/FavoriteFolderServiceTest.java
@@ -3,6 +3,7 @@ package com.sideproject.hororok.favorite.application;
 import com.sideproject.hororok.auth.dto.LoginMember;
 import com.sideproject.hororok.favorite.domain.FavoriteFolder;
 import com.sideproject.hororok.favorite.domain.FavoriteFolderRepository;
+import com.sideproject.hororok.favorite.domain.FavoriteRepository;
 import com.sideproject.hororok.favorite.dto.FavoriteFolderDto;
 import com.sideproject.hororok.favorite.dto.response.MyPlaceResponse;
 import com.sideproject.hororok.member.domain.Member;
@@ -28,6 +29,9 @@ class FavoriteFolderServiceTest{
     @Mock
     private FavoriteFolderRepository favoriteFolderRepository;
 
+    @Mock
+    private FavoriteRepository favoriteRepository;
+
     @InjectMocks
     private FavoriteFolderService favoriteFolderService;
 
@@ -44,7 +48,7 @@ class FavoriteFolderServiceTest{
         LoginMember loginMember = 로그인_맴버();
         when(favoriteFolderRepository
                 .countByMemberId(loginMember.getId()))
-                .thenReturn(폴더_있을때_개수);
+                .thenReturn(폴더_개수);
 
         Member member = 사용자();
         FavoriteFolder folder1 = 폴더1(member);
@@ -57,10 +61,10 @@ class FavoriteFolderServiceTest{
         MyPlaceResponse response = favoriteFolderService.myPlace(loginMember);
 
         //then
-        assertThat(response.getCount()).isEqualTo(폴더_있을때_개수);
-        assertThat(response.getFolders().size()).isEqualTo(폴더_있을때_리스트_사이즈);
-        assertThat(response.getFolders().get(폴더_있을때_리스트_인덱스1).getName()).isEqualTo(즐겨찾기_폴더_이름1);
-        assertThat(response.getFolders().get(폴더_있을때_리스트_인덱스2).getName()).isEqualTo(즐겨찾기_폴더_이름2);
+        assertThat(response.getFolderCount()).isEqualTo(폴더_개수);
+        assertThat(response.getFolders().size()).isEqualTo(폴더_리스트_사이즈);
+        assertThat(response.getFolders().get(폴더_리스트_인덱스1).getName()).isEqualTo(즐겨찾기_폴더_이름1);
+        assertThat(response.getFolders().get(폴더_리스트_인덱스2).getName()).isEqualTo(즐겨찾기_폴더_이름2);
     }
 
     @Test

--- a/src/test/java/com/sideproject/hororok/favorite/domain/FavoriteRepositoryTest.java
+++ b/src/test/java/com/sideproject/hororok/favorite/domain/FavoriteRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.sideproject.hororok.favorite.domain;
+
+import com.sideproject.hororok.cafe.domain.Cafe;
+import com.sideproject.hororok.cafe.domain.CafeRepository;
+import com.sideproject.hororok.common.annotation.RepositoryTest;
+import com.sideproject.hororok.member.domain.Member;
+import com.sideproject.hororok.member.domain.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.sideproject.hororok.common.fixtures.CafeFixtures.카페;
+import static com.sideproject.hororok.common.fixtures.FavoriteFixtures.즐겨찾기;
+import static com.sideproject.hororok.common.fixtures.FavoriteFolderFixtures.폴더1;
+import static com.sideproject.hororok.common.fixtures.MemberFixtures.사용자;
+import static org.assertj.core.api.Assertions.*;
+
+public class FavoriteRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+
+    @Autowired
+    private FavoriteFolderRepository favoriteFolderRepository;
+
+    @Test
+    @DisplayName("즐겨찾기 폴더의 ID와 연결된 즐겨찾기의 개수를 조회한다.")
+    public void testCountByFavoriteFolderId() {
+
+        //given
+        Cafe savedCafe = cafeRepository.save(카페());
+        Member savedMember = memberRepository.save(사용자());
+        FavoriteFolder savedFolder = favoriteFolderRepository.save(폴더1(savedMember));
+        Favorite savedFavorite = favoriteRepository.save(즐겨찾기(savedCafe, savedFolder));
+
+        //when
+        Long count = favoriteRepository.countByFavoriteFolderId(savedFolder.getId());
+
+        //then
+        assertThat(count).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/sideproject/hororok/favorite/presentation/FavoriteControllerTest.java
+++ b/src/test/java/com/sideproject/hororok/favorite/presentation/FavoriteControllerTest.java
@@ -33,16 +33,16 @@ class FavoriteControllerTest extends ControllerTest {
 
         List<FavoriteFolderDto> fakeFolders = new ArrayList<>();
         FavoriteFolderDto favoriteFolderDto1 =
-                폴더_Dto(폴더_있을때_ID_1, 즐겨찾기_폴더_이름1,
+                폴더_Dto(폴더_ID_1, 즐겨찾기_폴더_이름1,
                         즐겨찾기_폴더_색상1, 즐겨찾기_폴더_노출여부1);
 
         FavoriteFolderDto favoriteFolderDto2 =
-                폴더_Dto(폴더_있을때_ID_2, 즐겨찾기_폴더_이름2,
+                폴더_Dto(폴더_ID_2, 즐겨찾기_폴더_이름2,
                         즐겨찾기_폴더_색상2, 즐겨찾기_폴더_노출여부2);
         fakeFolders.add(favoriteFolderDto1);
         fakeFolders.add(favoriteFolderDto2);
 
-        MyPlaceResponse fakeResponse = 마이_플레이스_응답(폴더_있을때_개수, fakeFolders);
+        MyPlaceResponse fakeResponse = 마이_플레이스_응답(폴더_개수, fakeFolders);
 
 
         when(favoriteFolderService
@@ -55,13 +55,13 @@ class FavoriteControllerTest extends ControllerTest {
                             .accept(MediaType.APPLICATION_JSON)
                             .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.count").value(폴더_있을때_개수))
+                .andExpect(jsonPath("$.folderCount").value(폴더_개수))
                 .andExpect(jsonPath("$.folders").isArray())
-                .andExpect(jsonPath("$.folders", hasSize(폴더_있을때_리스트_사이즈)))
-                .andExpect(jsonPath("$.folders["+폴더_있을때_리스트_인덱스1+"].folderId").value(폴더_있을때_ID_1))
-                .andExpect(jsonPath("$.folders["+폴더_있을때_리스트_인덱스1+"].name").value(즐겨찾기_폴더_이름1))
-                .andExpect(jsonPath("$.folders["+폴더_있을때_리스트_인덱스2+"].folderId").value(폴더_있을때_ID_2))
-                .andExpect(jsonPath("$.folders["+폴더_있을때_리스트_인덱스2+"].name").value(즐겨찾기_폴더_이름2));
+                .andExpect(jsonPath("$.folders", hasSize(폴더_리스트_사이즈)))
+                .andExpect(jsonPath("$.folders["+폴더_리스트_인덱스1+"].folderId").value(폴더_ID_1))
+                .andExpect(jsonPath("$.folders["+폴더_리스트_인덱스1+"].name").value(즐겨찾기_폴더_이름1))
+                .andExpect(jsonPath("$.folders["+폴더_리스트_인덱스2+"].folderId").value(폴더_ID_2))
+                .andExpect(jsonPath("$.folders["+폴더_리스트_인덱스2+"].name").value(즐겨찾기_폴더_이름2));
     }
 
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
> 앱 하단 탭의 "저장" 버튼을 눌렀을 때 동작하는 기능에 폴더 내 즐겨찾기 개수를 퐇마하여 전달하도록 구현

### 연관된 이슈
> #78 

