### PR TITLE
feat(#87): 폴더 목록 옆 토글 버튼을 눌렀을 때 visible 값을 전환하는 기능 구현

### DIFF
--- a/src/main/java/com/sideproject/hororok/favorite/application/BookmarkFolderService.java
+++ b/src/main/java/com/sideproject/hororok/favorite/application/BookmarkFolderService.java
@@ -73,4 +73,14 @@ public class BookmarkFolderService {
         return bookmarkFolders(loginMember);
     }
 
+    @Transactional
+    public void updateFolderVisible(Long folderId) {
+
+        BookmarkFolder findFolder = bookmarkFolderRepository.findById(folderId)
+                .orElseThrow(() -> new EntityNotFoundException("폴더가 존재하지 않습니다."));
+
+        findFolder.changeVisible();
+        bookmarkFolderRepository.save(findFolder);
+    }
+
 }

--- a/src/main/java/com/sideproject/hororok/favorite/domain/BookmarkFolder.java
+++ b/src/main/java/com/sideproject/hororok/favorite/domain/BookmarkFolder.java
@@ -47,4 +47,8 @@ public class BookmarkFolder {
         this.color = request.getColor();
         this.isVisible = request.getIsVisible();
     }
+
+    public void changeVisible() {
+        this.isVisible = !isVisible;
+    }
 }

--- a/src/main/java/com/sideproject/hororok/favorite/presentation/BookmarkController.java
+++ b/src/main/java/com/sideproject/hororok/favorite/presentation/BookmarkController.java
@@ -47,4 +47,14 @@ public class BookmarkController {
         BookmarkFoldersResponse response = bookmarkFolderService.update(request, loginMember);
         return ResponseEntity.ok(response);
     }
+
+    @PutMapping("/folder/{folderId}/update/visible")
+    @Operation(summary = "폴더의  토글(지도 노출 여부) 버튼을 눌렀을 때 동작하는 기능")
+    public ResponseEntity<Void> folderVisibleUpdate(
+            @AuthenticationPrincipal LoginMember loginMember,
+            @PathVariable Long folderId){
+
+        bookmarkFolderService.updateFolderVisible(folderId);
+        return ResponseEntity.noContent().build();
+    }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
> 앱 하단 탭의 "저장" 버튼을 눌렀을 때 동작하는 기능에 폴더 내 즐겨찾기 개수를 퐇마하여 전달하도록 구현

### 연관된 이슈
> #87 

