### PR TITLE
chore(#152): build.gradle에 jacoco를 도입 현재는 커버리지 제한을 걸지 않는다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,10 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'org.springframework.boot' version '3.2.4'
 	id 'io.spring.dependency-management' version '1.1.4'
 	id "org.asciidoctor.jvm.convert" version "3.3.2"
+
 }
 
 group = 'com.example'
@@ -86,7 +88,41 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy 'jacocoTestReport'
 }
+
+jacocoTestReport {
+	reports {
+		html.destination file("$buildDir/jacoco/report.html")
+	}
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true
+			element = 'CLASS'
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.00
+			}
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.00
+			}
+			limit {
+				counter = 'LINE'
+				value = 'TOTALCOUNT'
+				maximum = 500
+			}
+		}
+	}
+}
+
+
 
 clean {
 	delete file('src/main/generated')


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- [x] 테스트 코드 측정 도구인 Jacoco 도입

### 연관된 이슈
> #152 

