### PR TITLE
fix: 토큰 정보가 만료된 경우에 로그인이 안된 상태로 검색이 가능하게 변경

### DIFF
--- a/src/main/java/com/sideproject/hororok/cafe/presentation/CafeController.java
+++ b/src/main/java/com/sideproject/hororok/cafe/presentation/CafeController.java
@@ -10,6 +10,7 @@ import com.sideproject.hororok.auth.presentation.AuthorizationExtractor;
 import com.sideproject.hororok.cafe.dto.request.CafeFindCategoryRequest;
 import com.sideproject.hororok.cafe.dto.response.*;
 import com.sideproject.hororok.cafe.application.CafeService;
+import com.sideproject.hororok.member.exception.NoSuchMemberException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -154,7 +155,8 @@ public class CafeController {
             String accessToken = AuthorizationExtractor.extract(request);
             Long memberId = authService.extractMemberId(accessToken);
             return memberId;
-        } catch (final InvalidTokenException | EmptyAuthorizationHeaderException  e) {
+        } catch (final InvalidTokenException | EmptyAuthorizationHeaderException |
+                       NoSuchMemberException e) {
             return null;
         }
     }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- 토큰 정보가 만료된 경우에 로그인이 안된 상태로 검색이 가능하게 변경


