### PR TITLE
fix(#185): /api/refresh 요청 시 500에러가 발생하는 문제를 수정

### DIFF
--- a/src/main/java/com/sideproject/hororok/auth/domain/OAuthToken.java
+++ b/src/main/java/com/sideproject/hororok/auth/domain/OAuthToken.java
@@ -30,7 +30,7 @@ public class OAuthToken extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
-    public void change(final String refreshToken) {
+    public void changeRefreshToken(final String refreshToken) {
         if(!Objects.isNull(refreshToken)) {
             this.refreshToken = refreshToken;
         }

--- a/src/main/java/com/sideproject/hororok/auth/domain/redis/AuthRefreshToken.java
+++ b/src/main/java/com/sideproject/hororok/auth/domain/redis/AuthRefreshToken.java
@@ -17,4 +17,8 @@ public class AuthRefreshToken {
         this.memberId = memberId;
         this.refreshToken = refreshToken;
     }
+
+    public void changeRefreshToken(final String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/sideproject/hororok/auth/domain/redis/AuthRefreshTokenRepository.java
+++ b/src/main/java/com/sideproject/hororok/auth/domain/redis/AuthRefreshTokenRepository.java
@@ -1,7 +1,15 @@
 package com.sideproject.hororok.auth.domain.redis;
 
+import com.sideproject.hororok.auth.exception.NoSuchTokenException;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AuthRefreshTokenRepository extends CrudRepository<AuthRefreshToken, Long> {
+
+
+
+    default AuthRefreshToken getById(final Long memberId) {
+        return findById(memberId)
+                .orElseThrow(NoSuchTokenException::new);
+    }
 
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- [x] 문제의 원인 파악
  - 새로운 로그인 시 refresh token이 새로 발급되더라도 기존에 저장된 refresh token이 있으면 해당 값으로 사용하도록 설정되어 있었음
- [x] 문제 해결
  - /auth/login 요청시에는 카카오에 새로운 로그인을 요청하고 발급받은 refresh token을 DB에 저장
  - 새로 생성된 JWT refresh Token을 Redis에 추가 저장
  - /auth/refresh 요청시에는 전달받은 refresh token의 유효성 검사 후 해당 토큰으로 accessToken을 생성 반환

### 연관된 이슈
> #185 

