### PR TITLE
fix(#215): 프로필 변경 시 이미지 저장에서 바생하는 문제 해결을 위한 수정

### DIFF
--- a/src/main/java/com/sideproject/cafe_cok/utils/Constants.java
+++ b/src/main/java/com/sideproject/cafe_cok/utils/Constants.java
@@ -27,7 +27,7 @@ public class Constants {
     public static final List<DayOfWeek> operationDays =
             Arrays.asList(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY);
 
-    public static final String DECODED_URL_SPLIT_STR = "com/";
+    public static final String DECODED_URL_SPLIT_STR = "net/";
     public static final String URL_DECODER_DECODE_ENC = "UTF-8";
 
     public static final Integer RECOMMEND_MENU_MAX_CNT = 3;

--- a/src/main/java/com/sideproject/cafe_cok/utils/S3/component/S3Uploader.java
+++ b/src/main/java/com/sideproject/cafe_cok/utils/S3/component/S3Uploader.java
@@ -49,7 +49,9 @@ public class S3Uploader {
     }
 
     public void delete(String url) {
+        System.out.println("딜리트 위한 URL : " + url);
         String key = extractObjectKeyFromUrl(url);
+        System.out.println("딜리트 위한 키 : " + key);
         amazonS3Client.deleteObject(bucket, key);
     }
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- 기존 S3의 경우에는 "com/"으로 분리하면 뒷부분의 키 값을 얻을 수 있었으나, CloudFront는 "net/"으로 분리해야 키 값을 얻을 수 있으므로 분리 기준을 가지고 있는 상수 값을 변경해줌.

### 연관된 이슈
> #215
