### PR TITLE
fix(#217): 계획하기 기능에서 MATCH 카페의 목록이 노출되지 않는 문제를 해결하기 위한 수정

### DIFF
--- a/src/main/java/com/sideproject/cafe_cok/cafe/dto/CafeDto.java
+++ b/src/main/java/com/sideproject/cafe_cok/cafe/dto/CafeDto.java
@@ -41,6 +41,19 @@ public class CafeDto {
         this.bookmarks = bookmarks;
     }
 
+    public CafeDto(final Cafe cafe,
+                   final String imageUrl) {
+        this.id = cafe.getId();
+        this.name = cafe.getName();
+        this.phoneNumber = cafe.getPhoneNumber();
+        this.roadAddress = cafe.getRoadAddress();
+        this.latitude = cafe.getLatitude();
+        this.longitude = cafe.getLongitude();
+        this.starRating = cafe.getStarRating();
+        this.reviewCount = cafe.getReviewCount();
+        this.imageUrl = imageUrl;
+    }
+
     public void setBookmarks(final List<BookmarkIdDto> bookmarks) {
         this.bookmarks = bookmarks;
     }

--- a/src/main/java/com/sideproject/cafe_cok/member/domain/Member.java
+++ b/src/main/java/com/sideproject/cafe_cok/member/domain/Member.java
@@ -49,9 +49,6 @@ public class Member extends BaseEntity {
     @Column(name = "deletion_reason")
     private String deletionReason;
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private OAuthToken oauthToken;
-
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<BookmarkFolder> bookmarkFolders = new ArrayList<>();
 

--- a/src/test/java/com/sideproject/cafe_cok/common/fixtures/PlanFixtures.java
+++ b/src/test/java/com/sideproject/cafe_cok/common/fixtures/PlanFixtures.java
@@ -18,6 +18,7 @@ import java.time.LocalTime;
 import java.util.Collections;
 
 import static com.sideproject.cafe_cok.common.fixtures.CafeFixtures.*;
+import static com.sideproject.cafe_cok.common.fixtures.CafeFixtures.카페_DTO_리스트;
 import static com.sideproject.cafe_cok.common.fixtures.KeywordFixtures.*;
 import static com.sideproject.cafe_cok.common.fixtures.MemberFixtures.사용자;
 

--- a/src/test/java/com/sideproject/cafe_cok/plan/presentation/PlanControllerTest.java
+++ b/src/test/java/com/sideproject/cafe_cok/plan/presentation/PlanControllerTest.java
@@ -106,11 +106,12 @@ class PlanControllerTest extends ControllerTest {
         CreatePlanResponse response = 계획_응답();
 
         when(planService
-                .plan(any(CreatePlanRequest.class)))
+                .plan(any(CreatePlanRequest.class), any(Long.class)))
                 .thenReturn(response);
 
         mockMvc.perform(
                         post("/api/plan")
+                                .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                                 .accept(MediaType.APPLICATION_JSON)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
@@ -156,7 +157,8 @@ class PlanControllerTest extends ControllerTest {
                                 fieldWithPath("matchCafes").type(JsonFieldType.ARRAY)
                                         .description("일치하는 카페(결과 타입이 MATCH인 경우 존재, 아닌 경우 빈 리스트, 형식은 추천 카페와 동일)"),
                                 fieldWithPath("similarCafes").type(JsonFieldType.ARRAY)
-                                        .description("유사한 카페(결과 타입이 MATCH, SIMILAR인 경우 존재, 아닌 경우 빈 리스트, 형식은 추천 카페와 동일)"))))
+                                        .description("유사한 카페(결과 타입이 MATCH, SIMILAR인 경우 존재, 아닌 경우 빈 리스트, 형식은 추천 카페와 동일)")
+                        )))
                 .andExpect(status().isOk());
     }
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- 계획하기 기능에서 엔티티간 순환 참조 문제 해결을 위한 수정
- 게획에 일치/불일치/유사한 카페의 리스트를 출력하는 부분이 출력될 수 있도록 수정



### 연관된 이슈
> #217
