### PR TITLE
fix(#219): bookmark 관련 API2개 response 값 추가

### DIFF
--- a/src/main/java/com/sideproject/cafe_cok/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/sideproject/cafe_cok/bookmark/application/BookmarkService.java
@@ -2,6 +2,7 @@ package com.sideproject.cafe_cok.bookmark.application;
 
 import com.sideproject.cafe_cok.bookmark.domain.repository.BookmarkFolderRepository;
 import com.sideproject.cafe_cok.bookmark.dto.request.BookmarkSaveRequest;
+import com.sideproject.cafe_cok.bookmark.dto.response.BookmarkFolderAndBookmarkIdResponse;
 import com.sideproject.cafe_cok.bookmark.dto.response.BookmarkIdResponse;
 import com.sideproject.cafe_cok.cafe.domain.Cafe;
 import com.sideproject.cafe_cok.bookmark.domain.Bookmark;
@@ -22,17 +23,20 @@ public class BookmarkService {
     private final BookmarkFolderRepository bookmarkFolderRepository;
 
     @Transactional
-    public BookmarkIdResponse save(BookmarkSaveRequest request) {
+    public BookmarkFolderAndBookmarkIdResponse save(BookmarkSaveRequest request) {
 
         Cafe findCafe = cafeRepository.getById(request.getCafeId());
         BookmarkFolder findFolder = bookmarkFolderRepository.getById(request.getFolderId());
         Bookmark savedBookmark = bookmarkRepository.save(new Bookmark(findCafe, findFolder));
-        return new BookmarkIdResponse(savedBookmark.getId());
+        return new BookmarkFolderAndBookmarkIdResponse(
+                savedBookmark.getId(), savedBookmark.getBookmarkFolder().getId());
     }
 
     @Transactional
-    public BookmarkIdResponse delete(final Long bookmarkId) {
+    public BookmarkFolderAndBookmarkIdResponse delete(final Long bookmarkId) {
+        Bookmark findBookmark = bookmarkRepository.getById(bookmarkId);
         bookmarkRepository.deleteById(bookmarkId);
-        return new BookmarkIdResponse(bookmarkId);
+        return new BookmarkFolderAndBookmarkIdResponse(
+                findBookmark.getId(), findBookmark.getBookmarkFolder().getId());
     }
 }

--- a/src/main/java/com/sideproject/cafe_cok/bookmark/domain/repository/BookmarkRepository.java
+++ b/src/main/java/com/sideproject/cafe_cok/bookmark/domain/repository/BookmarkRepository.java
@@ -1,6 +1,7 @@
 package com.sideproject.cafe_cok.bookmark.domain.repository;
 
 import com.sideproject.cafe_cok.bookmark.domain.Bookmark;
+import com.sideproject.cafe_cok.bookmark.exception.NoSuchBookmarkException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -16,4 +17,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Bookm
                 "AND bf.member.id = :memberId")
     List<Bookmark> findByCafeIdAndMemberId(final Long cafeId, final Long memberId);
 
+    default Bookmark getById(final Long id) {
+        return findById(id)
+                .orElseThrow(NoSuchBookmarkException::new);
+    }
 }

--- a/src/main/java/com/sideproject/cafe_cok/bookmark/dto/response/BookmarkFolderAndBookmarkIdResponse.java
+++ b/src/main/java/com/sideproject/cafe_cok/bookmark/dto/response/BookmarkFolderAndBookmarkIdResponse.java
@@ -1,0 +1,20 @@
+package com.sideproject.cafe_cok.bookmark.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookmarkFolderAndBookmarkIdResponse {
+
+    private Long bookmarkId;
+    private Long bookmarkFolderId;
+
+    public BookmarkFolderAndBookmarkIdResponse(final Long bookmarkId,
+                                               final Long bookmarkFolderId) {
+        this.bookmarkId = bookmarkId;
+        this.bookmarkFolderId = bookmarkFolderId;
+    }
+
+}

--- a/src/main/java/com/sideproject/cafe_cok/bookmark/presentation/BookmarkController.java
+++ b/src/main/java/com/sideproject/cafe_cok/bookmark/presentation/BookmarkController.java
@@ -3,6 +3,7 @@ package com.sideproject.cafe_cok.bookmark.presentation;
 import com.sideproject.cafe_cok.auth.dto.LoginMember;
 import com.sideproject.cafe_cok.auth.presentation.AuthenticationPrincipal;
 import com.sideproject.cafe_cok.bookmark.dto.request.BookmarkSaveRequest;
+import com.sideproject.cafe_cok.bookmark.dto.response.BookmarkFolderAndBookmarkIdResponse;
 import com.sideproject.cafe_cok.bookmark.dto.response.BookmarkIdResponse;
 import com.sideproject.cafe_cok.bookmark.application.BookmarkService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,21 +22,21 @@ public class BookmarkController {
 
     @PostMapping("/save")
     @Operation(summary = "저장버튼 클릭 -> 폴더 선택 후 저장 완료 시 동작하는 기능")
-    public ResponseEntity<BookmarkIdResponse> saveBookmark(
+    public ResponseEntity<BookmarkFolderAndBookmarkIdResponse> saveBookmark(
             @AuthenticationPrincipal LoginMember loginMember,
             @RequestBody BookmarkSaveRequest request) {
 
-        BookmarkIdResponse response = bookmarkService.save(request);
+        BookmarkFolderAndBookmarkIdResponse response = bookmarkService.save(request);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{bookmarkId}/delete")
     @Operation(summary = "저장된 북마크 삭제 기능")
-    public ResponseEntity<BookmarkIdResponse> deleteBookmark(
+    public ResponseEntity<BookmarkFolderAndBookmarkIdResponse> deleteBookmark(
             @AuthenticationPrincipal LoginMember loginMember,
             @PathVariable Long bookmarkId) {
 
-        BookmarkIdResponse response = bookmarkService.delete(bookmarkId);
+        BookmarkFolderAndBookmarkIdResponse response = bookmarkService.delete(bookmarkId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/resources/static/docs/api-doc-bookmark-folder.html
+++ b/src/main/resources/static/docs/api-doc-bookmark-folder.html
@@ -1237,7 +1237,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 302
+Content-Length: 303
 
 {
   "folderId" : 1,
@@ -1248,8 +1248,8 @@ Content-Length: 302
     "cafeId" : 1,
     "cafeName" : "카페 이름",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 154.03278808984473,
-    "longitude" : 50.079462337949
+    "latitude" : 79.93406789235112,
+    "longitude" : 54.54136081918581
   } ]
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/api-doc-bookmark.html
+++ b/src/main/resources/static/docs/api-doc-bookmark.html
@@ -668,10 +668,11 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 22
+Content-Length: 48
 
 {
-  "bookmarkId" : 1
+  "bookmarkId" : 1,
+  "bookmarkFolderId" : 1
 }</code></pre>
 </div>
 </div>
@@ -743,10 +744,11 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 22
+Content-Length: 48
 
 {
-  "bookmarkId" : 1
+  "bookmarkId" : 1,
+  "bookmarkFolderId" : 1
 }</code></pre>
 </div>
 </div>

--- a/src/main/resources/static/docs/api-doc-cafe.html
+++ b/src/main/resources/static/docs/api-doc-cafe.html
@@ -513,14 +513,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 449
+Content-Length: 450
 
 {
   "cafeId" : 1,
   "cafeName" : "카페 이름",
   "roadAddress" : "OO시 OO구 OO동",
-  "latitude" : 154.03278808984473,
-  "longitude" : 50.079462337949,
+  "latitude" : 79.93406789235112,
+  "longitude" : 54.54136081918581,
   "starRating" : 0,
   "reviewCount" : 0,
   "originUrl" : "원본_이미지_URL",
@@ -713,7 +713,7 @@ Content-Length: 1066
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-11",
+    "createDate" : "2024-06-17",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1209,7 +1209,7 @@ Content-Length: 118
 <h4 id="_http_request_6">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=50.079462337949&amp;longitude=154.03278808984473 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=54.54136081918581&amp;longitude=79.93406789235112 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1251,7 +1251,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 399
+Content-Length: 400
 
 {
   "cafes" : [ {
@@ -1259,8 +1259,8 @@ Content-Length: 399
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 154.03278808984473,
-    "longitude" : 50.079462337949,
+    "latitude" : 79.93406789235112,
+    "longitude" : 54.54136081918581,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1364,7 +1364,7 @@ Content-Length: 399
 <h4 id="_http_request_7">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=50.079462337949&amp;longitude=154.03278808984473 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=54.54136081918581&amp;longitude=79.93406789235112 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1406,7 +1406,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 399
+Content-Length: 400
 
 {
   "cafes" : [ {
@@ -1414,8 +1414,8 @@ Content-Length: 399
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 154.03278808984473,
-    "longitude" : 50.079462337949,
+    "latitude" : 79.93406789235112,
+    "longitude" : 54.54136081918581,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1524,12 +1524,12 @@ Content-Length: 399
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
-Content-Length: 109
+Content-Length: 110
 Host: localhost:8080
 
 {
-  "latitude" : 50.079462337949,
-  "longitude" : 154.03278808984473,
+  "latitude" : 54.54136081918581,
+  "longitude" : 79.93406789235112,
   "keywords" : [ "키워드 이름" ]
 }</code></pre>
 </div>
@@ -1578,7 +1578,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 399
+Content-Length: 400
 
 {
   "cafes" : [ {
@@ -1586,8 +1586,8 @@ Content-Length: 399
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 154.03278808984473,
-    "longitude" : 50.079462337949,
+    "latitude" : 79.93406789235112,
+    "longitude" : 54.54136081918581,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1762,7 +1762,7 @@ Content-Length: 548
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-11",
+    "createDate" : "2024-06-17",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1938,7 +1938,7 @@ Content-Length: 508
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-11",
+    "createDate" : "2024-06-17",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {

--- a/src/main/resources/static/docs/api-doc-myPage.html
+++ b/src/main/resources/static/docs/api-doc-myPage.html
@@ -759,7 +759,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 11일 9시 0분",
+    "visitDateTime" : "6월 17일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -898,7 +898,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 11일 9시 0분",
+    "visitDateTime" : "6월 17일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1021,14 +1021,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 1101
+Content-Length: 1103
 
 {
   "planId" : 1,
   "matchType" : "SIMILAR",
   "locationName" : "위치 이름",
   "minutes" : 10,
-  "visitDateTime" : "6월 11일 9시 0분",
+  "visitDateTime" : "6월 17일 9시 0분",
   "categoryKeywords" : {
     "purpose" : [ "키워드 이름" ],
     "menu" : [ ],
@@ -1041,8 +1041,8 @@ Content-Length: 1101
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 154.03278808984473,
-    "longitude" : 50.079462337949,
+    "latitude" : 79.93406789235112,
+    "longitude" : 54.54136081918581,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1056,8 +1056,8 @@ Content-Length: 1101
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 154.03278808984473,
-    "longitude" : 50.079462337949,
+    "latitude" : 79.93406789235112,
+    "longitude" : 54.54136081918581,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1461,7 +1461,7 @@ Content-Length: 464
     "starRating" : 5,
     "content" : "리뷰 내용",
     "specialNote" : "리뷰 특이사항",
-    "createdDate" : "2024-06-11",
+    "createdDate" : "2024-06-17",
     "imageUrls" : [ {
       "originUrl" : "원본_이미지_URL",
       "thumbnailUrl" : "썸네일_이미지_URL"
@@ -1740,7 +1740,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 11일 9시 0분",
+    "visitDateTime" : "6월 17일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1865,7 +1865,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 11일 9시 0분",
+    "visitDateTime" : "6월 17일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>

--- a/src/main/resources/static/docs/api-doc-plan.html
+++ b/src/main/resources/static/docs/api-doc-plan.html
@@ -474,16 +474,17 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/plan HTTP/1.1
 Content-Type: application/json
+Authorization: Bearer JWT TOKEN
 Accept: application/json
 Content-Length: 243
 Host: localhost:8080
 
 {
   "locationName" : "위치 이름",
-  "latitude" : 75.66977290857479,
-  "longitude" : 98.99273362218456,
+  "latitude" : 83.7107741483215,
+  "longitude" : 126.84373242947811,
   "minutes" : 10,
-  "date" : "2024-06-11",
+  "date" : "2024-06-17",
   "startTime" : "09:00:00",
   "endTime" : "11:00:00",
   "keywords" : [ "키워드 이름" ]
@@ -559,7 +560,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 751
+Content-Length: 752
 
 {
   "planId" : 1,
@@ -579,8 +580,8 @@ Content-Length: 751
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 154.03278808984473,
-    "longitude" : 50.079462337949,
+    "latitude" : 79.93406789235112,
+    "longitude" : 54.54136081918581,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",

--- a/src/test/java/com/sideproject/cafe_cok/bookmark/presentation/BookmarkControllerTest.java
+++ b/src/test/java/com/sideproject/cafe_cok/bookmark/presentation/BookmarkControllerTest.java
@@ -1,5 +1,6 @@
 package com.sideproject.cafe_cok.bookmark.presentation;
 
+import com.sideproject.cafe_cok.bookmark.dto.response.BookmarkFolderAndBookmarkIdResponse;
 import com.sideproject.cafe_cok.bookmark.dto.response.BookmarkIdResponse;
 import com.sideproject.cafe_cok.common.annotation.ControllerTest;
 import com.sideproject.cafe_cok.bookmark.dto.request.BookmarkSaveRequest;
@@ -41,7 +42,7 @@ class BookmarkControllerTest extends ControllerTest {
     public void test_save_bookmark_post() throws Exception {
 
         BookmarkSaveRequest request = 북마크_저장_요청();
-        BookmarkIdResponse response = 북마크_ID_응답();
+        BookmarkFolderAndBookmarkIdResponse response = 북마크폴더_북마크_ID_응답();
 
         when(bookmarkService.save(any(BookmarkSaveRequest.class))).thenReturn(response);
 
@@ -56,7 +57,8 @@ class BookmarkControllerTest extends ControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(headerWithName("Authorization").description("Bearer JWT 엑세스 토큰")),
-                        responseFields(fieldWithPath("bookmarkId").description("저장한 북마크 ID")),
+                        responseFields(fieldWithPath("bookmarkId").description("저장한 북마크 ID"),
+                                fieldWithPath("bookmarkFolderId").description("저장한 북마크의 폴더 ID")),
                         requestFields(
                                 fieldWithPath("cafeId").description("저장하려는 카페 Id"),
                                 fieldWithPath("folderId").description("저장하려는 폴더 ID"))))
@@ -74,7 +76,7 @@ class BookmarkControllerTest extends ControllerTest {
     public void test_delete_bookmark_success() throws Exception {
 
         Long bookmarkId = 북마크_ID;
-        BookmarkIdResponse response = 북마크_ID_응답();
+        BookmarkFolderAndBookmarkIdResponse response = 북마크폴더_북마크_ID_응답();
 
         when(bookmarkService.delete(any(Long.class))).thenReturn(response);
 
@@ -88,7 +90,8 @@ class BookmarkControllerTest extends ControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(headerWithName("Authorization").description("Bearer JWT 엑세스 토큰")),
-                        responseFields(fieldWithPath("bookmarkId").description("삭제한 북마크 ID")),
+                        responseFields(fieldWithPath("bookmarkId").description("삭제한 북마크 ID"),
+                                fieldWithPath("bookmarkFolderId").description("삭제한 북마크의 폴더 ID")),
                         pathParameters(parameterWithName("bookmarkId").description("삭제할 북마크의 ID"))))
                 .andExpect(status().isOk());
 

--- a/src/test/java/com/sideproject/cafe_cok/common/fixtures/BookmarkFixtures.java
+++ b/src/test/java/com/sideproject/cafe_cok/common/fixtures/BookmarkFixtures.java
@@ -2,6 +2,7 @@ package com.sideproject.cafe_cok.common.fixtures;
 
 import com.sideproject.cafe_cok.bookmark.dto.BookmarkCafeDto;
 import com.sideproject.cafe_cok.bookmark.dto.BookmarkIdDto;
+import com.sideproject.cafe_cok.bookmark.dto.response.BookmarkFolderAndBookmarkIdResponse;
 import com.sideproject.cafe_cok.bookmark.dto.response.BookmarkIdResponse;
 import com.sideproject.cafe_cok.bookmark.domain.Bookmark;
 import com.sideproject.cafe_cok.bookmark.dto.request.BookmarkSaveRequest;
@@ -47,6 +48,10 @@ public class BookmarkFixtures {
 
     public static BookmarkIdResponse 북마크_ID_응답() {
         return new BookmarkIdResponse(북마크_ID);
+    }
+
+    public static BookmarkFolderAndBookmarkIdResponse 북마크폴더_북마크_ID_응답() {
+        return new BookmarkFolderAndBookmarkIdResponse(북마크_ID, 북마크_폴더_ID);
     }
 
     public static Bookmark setId(Bookmark bookmark, final Long id) {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- 아래 2개의 api의 response 값에 folderId를 추가로 전달
- BookmarkFolderAndBookmarkIdResponse 응답 객체 추가 아래 2개의 API에 대해서 해당 객체를 리턴하도록 변경
- api/bookmark/{bookmarkId}/delete
- api/bopokmark/save


### 연관된 이슈
> #219 
