### PR TITLE
fix(#223): Map API 변경에 따른 좌표 저장 로직 수정(naver -> kakao)

### DIFF
--- a/src/main/java/com/sideproject/cafe_cok/admin/dto/request/AdminCafeSaveRequest.java
+++ b/src/main/java/com/sideproject/cafe_cok/admin/dto/request/AdminCafeSaveRequest.java
@@ -3,12 +3,16 @@ package com.sideproject.cafe_cok.admin.dto.request;
 import com.sideproject.cafe_cok.cafe.domain.Cafe;
 import com.sideproject.cafe_cok.utils.FormatConverter;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AdminCafeSaveRequest {
 
     @NotNull
@@ -16,19 +20,20 @@ public class AdminCafeSaveRequest {
     @NotNull
     private String roadAddress;
     @NotNull
-    private Integer mapx;
+    private BigDecimal mapx;
     @NotNull
-    private Integer mapy;
+    private BigDecimal mapy;
     private String telephone;
     private List<AdminMenuSaveRequest> menus;
     private List<List<String>> hours;
 
-    protected AdminCafeSaveRequest() {
-    }
-
-    public AdminCafeSaveRequest(final String name, final String roadAddress,
-                                final Integer mapx, final Integer mapy, final String telephone,
-                                final List<AdminMenuSaveRequest> menus, final List<List<String>> hours) {
+    public AdminCafeSaveRequest(final String name,
+                                final String roadAddress,
+                                final BigDecimal mapx,
+                                final BigDecimal mapy,
+                                final String telephone,
+                                final List<AdminMenuSaveRequest> menus,
+                                final List<List<String>> hours) {
         this.name = name;
         this.roadAddress = roadAddress;
         this.mapx = mapx;
@@ -38,8 +43,11 @@ public class AdminCafeSaveRequest {
         this.hours = hours;
     }
 
-    public AdminCafeSaveRequest(final String name, final String roadAddress,
-                                final Integer mapx, final Integer mapy, final String telephone) {
+    public AdminCafeSaveRequest(final String name,
+                                final String roadAddress,
+                                final BigDecimal mapx,
+                                final BigDecimal mapy,
+                                final String telephone) {
         this.name = name;
         this.roadAddress = roadAddress;
         this.mapx = mapx;

--- a/src/main/java/com/sideproject/cafe_cok/admin/dto/response/AdminCafeSaveResponse.java
+++ b/src/main/java/com/sideproject/cafe_cok/admin/dto/response/AdminCafeSaveResponse.java
@@ -7,6 +7,7 @@ import com.sideproject.cafe_cok.menu.dto.CafeSaveMenuDto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Getter
@@ -16,8 +17,8 @@ public class AdminCafeSaveResponse {
     private Long id;
     private String name;
     private String roadAddress;
-    private Integer mapx;
-    private Integer mapy;
+    private BigDecimal mapx;
+    private BigDecimal mapy;
     private String telephone;
     private CafeMainImageDto mainImage;
     private List<CafeOtherImageDto> otherImages;
@@ -32,8 +33,8 @@ public class AdminCafeSaveResponse {
                 .id(cafe.getId())
                 .name(cafe.getName())
                 .roadAddress(cafe.getRoadAddress())
-                .mapx(cafe.getMapx())
-                .mapy(cafe.getMapy())
+                .mapx(cafe.getLongitude())
+                .mapy(cafe.getLatitude())
                 .telephone(cafe.getPhoneNumber())
                 .mainImage(mainImage)
                 .otherImages(otherImages)

--- a/src/main/java/com/sideproject/cafe_cok/cafe/domain/Cafe.java
+++ b/src/main/java/com/sideproject/cafe_cok/cafe/domain/Cafe.java
@@ -27,7 +27,8 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Table(name = "cafes")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Cafe extends BaseEntity {
+public class
+Cafe extends BaseEntity {
 
     private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile("^\\d{2,5}-\\d{3,4}-\\d{4}$");
     private static final Integer X_NUM_DIGITS = 3;
@@ -61,12 +62,6 @@ public class Cafe extends BaseEntity {
     @Column(name = "review_count")
     private Long reviewCount;
 
-    @Column(name = "mapx")
-    private Integer mapx;
-
-    @Column(name = "mapy")
-    private Integer mapy;
-
     @OneToMany(mappedBy = "cafe")
     private List<OperationHour> operationHours = new ArrayList<>();
 
@@ -76,30 +71,17 @@ public class Cafe extends BaseEntity {
     @OneToMany(mappedBy = "cafe")
     private List<Image> images = new ArrayList<>();
 
-    public Cafe(final String name, final String phoneNumber, final String roadAddress,
-                final BigDecimal longitude, final BigDecimal latitude) {
+    public Cafe(final String name,
+                final String phoneNumber,
+                final String roadAddress,
+                final BigDecimal longitude,
+                final BigDecimal latitude) {
         validatePhoneNumber(phoneNumber);
-
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.roadAddress = roadAddress;
         this.longitude = longitude;
         this.latitude = latitude;
-        this.starRating = BigDecimal.ZERO;
-        this.reviewCount = 0L;
-    }
-
-    public Cafe(final String name, final String phoneNumber, final String roadAddress,
-                final Integer mapx, final Integer mapy) {
-        validatePhoneNumber(phoneNumber);
-
-        this.name = name;
-        this.phoneNumber = phoneNumber;
-        this.roadAddress = roadAddress;
-        this.mapx = mapx;
-        this.mapy = mapy;
-        this.latitude = FormatConverter.convertToDecimal(mapy, Y_NUM_DIGITS);
-        this.longitude = FormatConverter.convertToDecimal(mapx, X_NUM_DIGITS);
         this.starRating = BigDecimal.ZERO;
         this.reviewCount = 0L;
     }

--- a/src/main/java/com/sideproject/cafe_cok/plan/application/PlanService.java
+++ b/src/main/java/com/sideproject/cafe_cok/plan/application/PlanService.java
@@ -138,7 +138,6 @@ public class PlanService {
                                                   final CategoryKeywordsDto categoryKeywords,
                                                   final Long memberId) {
 
-//        List<Cafe> recommendCafes = cafeRepository.findAllByOrderByStarRatingDescNameAsc();
         List<Cafe> recommendCafes = cafeRepository.findNearestCafes(request.getLatitude(), request.getLongitude());
         return CreatePlanResponse.builder()
                 .matchType(MatchType.MISMATCH)

--- a/src/main/resources/static/docs/api-doc-admin.html
+++ b/src/main/resources/static/docs/api-doc-admin.html
@@ -606,14 +606,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 672
+Content-Length: 698
 
 {
   "id" : 1,
   "name" : "카페 이름",
   "roadAddress" : "OO시 OO구 OO동",
-  "mapx" : null,
-  "mapy" : null,
+  "mapx" : 55.34462999494018,
+  "mapy" : 20.69166279661567,
   "telephone" : "010-1234-5678",
   "mainImage" : {
     "id" : 1,
@@ -674,12 +674,12 @@ Content-Length: 672
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>mapx</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">카페 경도</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>mapy</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">카페 위도</p></td>
 </tr>
 <tr>

--- a/src/main/resources/static/docs/api-doc-bookmark-folder.html
+++ b/src/main/resources/static/docs/api-doc-bookmark-folder.html
@@ -1031,8 +1031,8 @@ Content-Length: 204
     "name" : "폴더_이름",
     "color" : "폴더_색상",
     "bookmarkCount" : 1,
-    "visible" : true,
-    "defaultFolder" : false
+    "defaultFolder" : false,
+    "visible" : true
   } ]
 }</code></pre>
 </div>
@@ -1248,8 +1248,8 @@ Content-Length: 303
     "cafeId" : 1,
     "cafeName" : "카페 이름",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 79.93406789235112,
-    "longitude" : 54.54136081918581
+    "latitude" : 20.69166279661567,
+    "longitude" : 55.34462999494018
   } ]
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/api-doc-bookmark.html
+++ b/src/main/resources/static/docs/api-doc-bookmark.html
@@ -518,8 +518,8 @@ Content-Length: 204
     "name" : "폴더_이름",
     "color" : "폴더_색상",
     "bookmarkCount" : 1,
-    "visible" : true,
-    "defaultFolder" : false
+    "defaultFolder" : false,
+    "visible" : true
   } ]
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/api-doc-cafe.html
+++ b/src/main/resources/static/docs/api-doc-cafe.html
@@ -519,8 +519,8 @@ Content-Length: 450
   "cafeId" : 1,
   "cafeName" : "카페 이름",
   "roadAddress" : "OO시 OO구 OO동",
-  "latitude" : 79.93406789235112,
-  "longitude" : 54.54136081918581,
+  "latitude" : 20.69166279661567,
+  "longitude" : 55.34462999494018,
   "starRating" : 0,
   "reviewCount" : 0,
   "originUrl" : "원본_이미지_URL",
@@ -713,7 +713,7 @@ Content-Length: 1066
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-17",
+    "createDate" : "2024-06-22",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1209,7 +1209,7 @@ Content-Length: 118
 <h4 id="_http_request_6">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=54.54136081918581&amp;longitude=79.93406789235112 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=55.34462999494018&amp;longitude=20.69166279661567 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1259,8 +1259,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 79.93406789235112,
-    "longitude" : 54.54136081918581,
+    "latitude" : 20.69166279661567,
+    "longitude" : 55.34462999494018,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1364,7 +1364,7 @@ Content-Length: 400
 <h4 id="_http_request_7">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=54.54136081918581&amp;longitude=79.93406789235112 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=55.34462999494018&amp;longitude=20.69166279661567 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1414,8 +1414,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 79.93406789235112,
-    "longitude" : 54.54136081918581,
+    "latitude" : 20.69166279661567,
+    "longitude" : 55.34462999494018,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1528,8 +1528,8 @@ Content-Length: 110
 Host: localhost:8080
 
 {
-  "latitude" : 54.54136081918581,
-  "longitude" : 79.93406789235112,
+  "latitude" : 55.34462999494018,
+  "longitude" : 20.69166279661567,
   "keywords" : [ "키워드 이름" ]
 }</code></pre>
 </div>
@@ -1586,8 +1586,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 79.93406789235112,
-    "longitude" : 54.54136081918581,
+    "latitude" : 20.69166279661567,
+    "longitude" : 55.34462999494018,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1762,7 +1762,7 @@ Content-Length: 548
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-17",
+    "createDate" : "2024-06-22",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1938,7 +1938,7 @@ Content-Length: 508
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-17",
+    "createDate" : "2024-06-22",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {

--- a/src/main/resources/static/docs/api-doc-myPage.html
+++ b/src/main/resources/static/docs/api-doc-myPage.html
@@ -610,8 +610,8 @@ Content-Length: 204
     "name" : "폴더_이름",
     "color" : "폴더_색상",
     "bookmarkCount" : 1,
-    "visible" : true,
-    "defaultFolder" : false
+    "defaultFolder" : false,
+    "visible" : true
   } ]
 }</code></pre>
 </div>
@@ -759,7 +759,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 17일 9시 0분",
+    "visitDateTime" : "6월 22일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -898,7 +898,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 17일 9시 0분",
+    "visitDateTime" : "6월 22일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1028,7 +1028,7 @@ Content-Length: 1103
   "matchType" : "SIMILAR",
   "locationName" : "위치 이름",
   "minutes" : 10,
-  "visitDateTime" : "6월 17일 9시 0분",
+  "visitDateTime" : "6월 22일 9시 0분",
   "categoryKeywords" : {
     "purpose" : [ "키워드 이름" ],
     "menu" : [ ],
@@ -1041,8 +1041,8 @@ Content-Length: 1103
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 79.93406789235112,
-    "longitude" : 54.54136081918581,
+    "latitude" : 20.69166279661567,
+    "longitude" : 55.34462999494018,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1056,8 +1056,8 @@ Content-Length: 1103
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 79.93406789235112,
-    "longitude" : 54.54136081918581,
+    "latitude" : 20.69166279661567,
+    "longitude" : 55.34462999494018,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1461,7 +1461,7 @@ Content-Length: 464
     "starRating" : 5,
     "content" : "리뷰 내용",
     "specialNote" : "리뷰 특이사항",
-    "createdDate" : "2024-06-17",
+    "createdDate" : "2024-06-22",
     "imageUrls" : [ {
       "originUrl" : "원본_이미지_URL",
       "thumbnailUrl" : "썸네일_이미지_URL"
@@ -1740,7 +1740,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 17일 9시 0분",
+    "visitDateTime" : "6월 22일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1865,7 +1865,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 17일 9시 0분",
+    "visitDateTime" : "6월 22일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>

--- a/src/main/resources/static/docs/api-doc-plan.html
+++ b/src/main/resources/static/docs/api-doc-plan.html
@@ -476,15 +476,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 Content-Type: application/json
 Authorization: Bearer JWT TOKEN
 Accept: application/json
-Content-Length: 243
+Content-Length: 245
 Host: localhost:8080
 
 {
   "locationName" : "위치 이름",
-  "latitude" : 83.7107741483215,
-  "longitude" : 126.84373242947811,
+  "latitude" : 20.117813290329618,
+  "longitude" : 49.247562840361965,
   "minutes" : 10,
-  "date" : "2024-06-17",
+  "date" : "2024-06-22",
   "startTime" : "09:00:00",
   "endTime" : "11:00:00",
   "keywords" : [ "키워드 이름" ]
@@ -580,8 +580,8 @@ Content-Length: 752
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 79.93406789235112,
-    "longitude" : 54.54136081918581,
+    "latitude" : 20.69166279661567,
+    "longitude" : 55.34462999494018,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",

--- a/src/test/java/com/sideproject/cafe_cok/common/fixtures/AdminFixtures.java
+++ b/src/test/java/com/sideproject/cafe_cok/common/fixtures/AdminFixtures.java
@@ -9,6 +9,7 @@ import com.sideproject.cafe_cok.image.dto.CafeMainImageDto;
 import com.sideproject.cafe_cok.image.dto.CafeOtherImageDto;
 import com.sideproject.cafe_cok.menu.dto.CafeSaveMenuDto;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -23,9 +24,8 @@ public class AdminFixtures {
     private static final String 메뉴_이름 = "메뉴 이름";
     private static final Integer 메뉴_가격 = 10000;
     private static final String 메뉴_이미지 = "Base64로 인코딩된 이미지 정보";
-
-    public static final Integer X_좌표 = 123456789;
-    public static final Integer Y_좌표 = 123456789;
+    public static final BigDecimal X_좌표 = new BigDecimal(123456789);
+    public static final BigDecimal Y_좌표 = new BigDecimal(123456789);
 
     public static AdminCafeSaveRequest 카페_저장_요청() {
         return new AdminCafeSaveRequest(카페_이름, 카페_도로명_주소, X_좌표, Y_좌표, 카페_전화번호,


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
-  Map API 변경에 따른 좌표 저장 로직 수정(naver -> kakao)
  - 네이버 map 좌표계를 전달받아 kakao map 좌표계로 전환하는 로직이 필요없어짐으로 인한 제거
  - 테이블에 네이버의 좌표계를 저장하는 컬럼(mapx, mapy) 제거

### 연관된 이슈
> #223
