### PR TITLE
fix(#234): 회원 탈퇴 이유와 개선의견을 저장할 수 있는 엔티티를 만들고 로직을 수정 및 추가

### DIFF
--- a/src/docs/asciidoc/api-doc-myPage.adoc
+++ b/src/docs/asciidoc/api-doc-myPage.adoc
@@ -121,12 +121,12 @@ include::{snippets}/myPage/shared/plans/all/success/response-fields.adoc[]
 
 === 4-13.개선 의견 남기기 - 성공
 ==== Request Header
-include::{snippets}/myPage/add/feedback/success/request-headers.adoc[]
+include::{snippets}/myPage/feedback/success/request-headers.adoc[]
 ==== Http request
-include::{snippets}/myPage/add/feedback/success/http-request.adoc[]
+include::{snippets}/myPage/feedback/success/http-request.adoc[]
 ==== Request fields
-include::{snippets}/myPage/add/feedback/success/request-fields.adoc[]
+include::{snippets}/myPage/feedback/success/request-fields.adoc[]
 ==== Http Response
-include::{snippets}/myPage/add/feedback/success/http-response.adoc[]
+include::{snippets}/myPage/feedback/success/http-response.adoc[]
 
 === link:api-docs.html[API 목록으로]

--- a/src/main/java/com/sideproject/cafe_cok/admin/application/AdminService.java
+++ b/src/main/java/com/sideproject/cafe_cok/admin/application/AdminService.java
@@ -113,7 +113,6 @@ public class AdminService {
         if (findMember.getDeletedAt() == null) throw new NoWithdrawalMemberException();
 
         findMember.changeDeletedAt(null);
-        findMember.changeDeletionReason(null);
 
         List<Review> findReviews = findMember.getReviews();
         findReviews.stream()

--- a/src/main/java/com/sideproject/cafe_cok/auth/application/AuthService.java
+++ b/src/main/java/com/sideproject/cafe_cok/auth/application/AuthService.java
@@ -3,6 +3,9 @@ package com.sideproject.cafe_cok.auth.application;
 import com.sideproject.cafe_cok.auth.dto.LoginMember;
 import com.sideproject.cafe_cok.auth.dto.OAuthMember;
 import com.sideproject.cafe_cok.auth.exception.InvalidRestoreMemberException;
+import com.sideproject.cafe_cok.member.domain.Feedback;
+import com.sideproject.cafe_cok.member.domain.enums.FeedbackCategory;
+import com.sideproject.cafe_cok.member.domain.repository.FeedbackRepository;
 import com.sideproject.cafe_cok.member.domain.repository.MemberRepository;
 import com.sideproject.cafe_cok.auth.domain.AuthToken;
 import com.sideproject.cafe_cok.auth.domain.OAuthToken;
@@ -32,6 +35,7 @@ public class AuthService {
 
     private final TokenCreator tokenCreator;
     private final MemberRepository memberRepository;
+    private final FeedbackRepository feedbackRepository;
     private final OAuthTokenRepository oAuthTokenRepository;
     private final AuthRefreshTokenRepository authRefreshTokenRepository;
     private final BookmarkFolderRepository bookmarkFolderRepository;
@@ -78,8 +82,12 @@ public class AuthService {
 
         Member findMember = memberRepository.getById(loginMember.getId());
         findMember.changeDeletedAt(LocalDateTime.now());
-        findMember.changeDeletionReason(reason);
 
+        Feedback newFeedback = new Feedback(
+                findMember.getEmail(),
+                FeedbackCategory.WITHDRAWAL_REASON,
+                reason);
+        feedbackRepository.save(newFeedback);
         List<Review> findReviews = findMember.getReviews();
         findReviews.stream()
                 .forEach(review -> review.getCafe().minusReviewCountAndCalculateStarRating(review.getStarRating()));

--- a/src/main/java/com/sideproject/cafe_cok/member/application/MyPageService.java
+++ b/src/main/java/com/sideproject/cafe_cok/member/application/MyPageService.java
@@ -1,5 +1,6 @@
 package com.sideproject.cafe_cok.member.application;
 
+import com.sideproject.cafe_cok.member.domain.enums.FeedbackCategory;
 import com.sideproject.cafe_cok.member.dto.request.MemberFeedbackRequest;
 import com.sideproject.cafe_cok.auth.dto.LoginMember;
 import com.sideproject.cafe_cok.bookmark.domain.repository.BookmarkRepository;
@@ -171,7 +172,10 @@ public class MyPageService {
                             final MemberFeedbackRequest request) {
 
         Member findMember = memberRepository.getById(loginMember.getId());
-        Feedback newFeedback = new Feedback(findMember.getEmail(), request.getContent());
+        Feedback newFeedback = new Feedback(
+                findMember.getEmail(),
+                FeedbackCategory.IMPROVEMENT_SUGGESTION,
+                request.getContent());
         feedbackRepository.save(newFeedback);
     }
 }

--- a/src/main/java/com/sideproject/cafe_cok/member/domain/Feedback.java
+++ b/src/main/java/com/sideproject/cafe_cok/member/domain/Feedback.java
@@ -1,5 +1,6 @@
 package com.sideproject.cafe_cok.member.domain;
 
+import com.sideproject.cafe_cok.member.domain.enums.FeedbackCategory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -21,9 +22,14 @@ public class Feedback {
     private String email;
     private String content;
 
+    @Enumerated(value = EnumType.STRING)
+    private FeedbackCategory category;
+
     public Feedback(final String email,
+                    final FeedbackCategory category,
                     final String content) {
         this.email = email;
+        this.category = category;
         this.content = content;
     }
 }

--- a/src/main/java/com/sideproject/cafe_cok/member/domain/Member.java
+++ b/src/main/java/com/sideproject/cafe_cok/member/domain/Member.java
@@ -46,9 +46,6 @@ public class Member extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @Column(name = "deletion_reason")
-    private String deletionReason;
-
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<BookmarkFolder> bookmarkFolders = new ArrayList<>();
 
@@ -92,9 +89,6 @@ public class Member extends BaseEntity {
         this.deletedAt = deletedAt;
     }
 
-    public void changeDeletionReason(final String deletionReason) {
-        this.deletionReason = deletionReason;
-    }
 
 
 }

--- a/src/main/java/com/sideproject/cafe_cok/member/domain/enums/FeedbackCategory.java
+++ b/src/main/java/com/sideproject/cafe_cok/member/domain/enums/FeedbackCategory.java
@@ -1,0 +1,6 @@
+package com.sideproject.cafe_cok.member.domain.enums;
+
+public enum FeedbackCategory {
+    WITHDRAWAL_REASON,
+    IMPROVEMENT_SUGGESTION
+}

--- a/src/main/java/com/sideproject/cafe_cok/member/presentation/MyPageController.java
+++ b/src/main/java/com/sideproject/cafe_cok/member/presentation/MyPageController.java
@@ -113,7 +113,7 @@ public class MyPageController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/add/feedback")
+    @PostMapping("/feedback")
     @Operation(summary = "마이페이지 개선 의견 남기기 기능")
     public ResponseEntity<Void> addFeedback(@AuthenticationPrincipal LoginMember loginMember,
                                             @RequestBody MemberFeedbackRequest request) {

--- a/src/main/resources/static/docs/api-doc-admin.html
+++ b/src/main/resources/static/docs/api-doc-admin.html
@@ -608,14 +608,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 698
+Content-Length: 699
 
 {
   "id" : 1,
   "name" : "카페 이름",
   "roadAddress" : "OO시 OO구 OO동",
-  "mapx" : 29.42000422259167,
-  "mapy" : 6.207163088849221,
+  "mapx" : 49.48827337139217,
+  "mapy" : 150.08345842730984,
   "telephone" : "010-1234-5678",
   "mainImage" : {
     "id" : 1,
@@ -799,7 +799,7 @@ Content-Length: 698
 <h4 id="_http_request_2">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/admin/cafe?mapx=6.207163088849221&amp;mapy=29.42000422259167 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/admin/cafe?mapx=150.08345842730984&amp;mapy=49.48827337139217 HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 Host: localhost:8080</code></pre>
@@ -840,15 +840,15 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 771
+Content-Length: 772
 
 {
   "cafe" : {
     "id" : 1,
     "name" : "카페 이름",
     "roadAddress" : "OO시 OO구 OO동",
-    "mapx" : 29.42000422259167,
-    "mapy" : 6.207163088849221,
+    "mapx" : 49.48827337139217,
+    "mapy" : 150.08345842730984,
     "telephone" : "010-1234-5678",
     "mainImage" : {
       "id" : 1,
@@ -1038,7 +1038,7 @@ Content-Length: 771
 <h4 id="_http_request_3">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/admin/cafe/exist?mapx=6.207163088849221&amp;mapy=29.42000422259167 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/admin/cafe/exist?mapx=150.08345842730984&amp;mapy=49.48827337139217 HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 Host: localhost:8080</code></pre>
@@ -1122,7 +1122,7 @@ Content-Length: 20
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-06-30 17:19:10 +0900
+Last updated 2024-06-30 17:22:09 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/api-doc-bookmark-folder.html
+++ b/src/main/resources/static/docs/api-doc-bookmark-folder.html
@@ -1031,8 +1031,8 @@ Content-Length: 204
     "name" : "폴더_이름",
     "color" : "폴더_색상",
     "bookmarkCount" : 1,
-    "visible" : true,
-    "defaultFolder" : false
+    "defaultFolder" : false,
+    "visible" : true
   } ]
 }</code></pre>
 </div>
@@ -1237,7 +1237,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 303
+Content-Length: 304
 
 {
   "folderId" : 1,
@@ -1248,8 +1248,8 @@ Content-Length: 303
     "cafeId" : 1,
     "cafeName" : "카페 이름",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 6.207163088849221,
-    "longitude" : 29.42000422259167
+    "latitude" : 150.08345842730984,
+    "longitude" : 49.48827337139217
   } ]
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/api-doc-bookmark.html
+++ b/src/main/resources/static/docs/api-doc-bookmark.html
@@ -518,8 +518,8 @@ Content-Length: 204
     "name" : "폴더_이름",
     "color" : "폴더_색상",
     "bookmarkCount" : 1,
-    "visible" : true,
-    "defaultFolder" : false
+    "defaultFolder" : false,
+    "visible" : true
   } ]
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/api-doc-cafe.html
+++ b/src/main/resources/static/docs/api-doc-cafe.html
@@ -513,14 +513,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 450
+Content-Length: 451
 
 {
   "cafeId" : 1,
   "cafeName" : "카페 이름",
   "roadAddress" : "OO시 OO구 OO동",
-  "latitude" : 6.207163088849221,
-  "longitude" : 29.42000422259167,
+  "latitude" : 150.08345842730984,
+  "longitude" : 49.48827337139217,
   "starRating" : 0,
   "reviewCount" : 0,
   "originUrl" : "원본_이미지_URL",
@@ -713,7 +713,7 @@ Content-Length: 1066
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-30",
+    "createDate" : "2024-07-10",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1209,7 +1209,7 @@ Content-Length: 118
 <h4 id="_http_request_6">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=29.42000422259167&amp;longitude=6.207163088849221 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=49.48827337139217&amp;longitude=150.08345842730984 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1251,7 +1251,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 400
+Content-Length: 401
 
 {
   "cafes" : [ {
@@ -1259,8 +1259,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 6.207163088849221,
-    "longitude" : 29.42000422259167,
+    "latitude" : 150.08345842730984,
+    "longitude" : 49.48827337139217,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1364,7 +1364,7 @@ Content-Length: 400
 <h4 id="_http_request_7">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=29.42000422259167&amp;longitude=6.207163088849221 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=49.48827337139217&amp;longitude=150.08345842730984 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1406,7 +1406,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 400
+Content-Length: 401
 
 {
   "cafes" : [ {
@@ -1414,8 +1414,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 6.207163088849221,
-    "longitude" : 29.42000422259167,
+    "latitude" : 150.08345842730984,
+    "longitude" : 49.48827337139217,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1524,12 +1524,12 @@ Content-Length: 400
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
-Content-Length: 110
+Content-Length: 111
 Host: localhost:8080
 
 {
-  "latitude" : 29.42000422259167,
-  "longitude" : 6.207163088849221,
+  "latitude" : 49.48827337139217,
+  "longitude" : 150.08345842730984,
   "keywords" : [ "키워드 이름" ]
 }</code></pre>
 </div>
@@ -1578,7 +1578,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 400
+Content-Length: 401
 
 {
   "cafes" : [ {
@@ -1586,8 +1586,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 6.207163088849221,
-    "longitude" : 29.42000422259167,
+    "latitude" : 150.08345842730984,
+    "longitude" : 49.48827337139217,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1762,7 +1762,7 @@ Content-Length: 548
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-30",
+    "createDate" : "2024-07-10",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1938,7 +1938,7 @@ Content-Length: 508
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-06-30",
+    "createDate" : "2024-07-10",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {

--- a/src/main/resources/static/docs/api-doc-myPage.html
+++ b/src/main/resources/static/docs/api-doc-myPage.html
@@ -611,8 +611,8 @@ Content-Length: 204
     "name" : "폴더_이름",
     "color" : "폴더_색상",
     "bookmarkCount" : 1,
-    "visible" : true,
-    "defaultFolder" : false
+    "defaultFolder" : false,
+    "visible" : true
   } ]
 }</code></pre>
 </div>
@@ -760,7 +760,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 30일 9시 0분",
+    "visitDateTime" : "7월 10일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -899,7 +899,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 30일 9시 0분",
+    "visitDateTime" : "7월 10일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1022,14 +1022,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 1103
+Content-Length: 1105
 
 {
   "planId" : 1,
   "matchType" : "SIMILAR",
   "locationName" : "위치 이름",
   "minutes" : 10,
-  "visitDateTime" : "6월 30일 9시 0분",
+  "visitDateTime" : "7월 10일 9시 0분",
   "categoryKeywords" : {
     "purpose" : [ "키워드 이름" ],
     "menu" : [ ],
@@ -1042,8 +1042,8 @@ Content-Length: 1103
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 6.207163088849221,
-    "longitude" : 29.42000422259167,
+    "latitude" : 150.08345842730984,
+    "longitude" : 49.48827337139217,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1057,8 +1057,8 @@ Content-Length: 1103
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 6.207163088849221,
-    "longitude" : 29.42000422259167,
+    "latitude" : 150.08345842730984,
+    "longitude" : 49.48827337139217,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1462,7 +1462,7 @@ Content-Length: 464
     "starRating" : 5,
     "content" : "리뷰 내용",
     "specialNote" : "리뷰 특이사항",
-    "createdDate" : "2024-06-30",
+    "createdDate" : "2024-07-10",
     "imageUrls" : [ {
       "originUrl" : "원본_이미지_URL",
       "thumbnailUrl" : "썸네일_이미지_URL"
@@ -1741,7 +1741,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 30일 9시 0분",
+    "visitDateTime" : "7월 10일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1866,7 +1866,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "6월 30일 9시 0분",
+    "visitDateTime" : "7월 10일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1945,7 +1945,7 @@ Content-Length: 158
 <h4 id="_http_request_11">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/myPage/add/feedback HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/myPage/feedback HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -2004,7 +2004,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-06-22 16:18:17 +0900
+Last updated 2024-07-10 13:17:03 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/api-doc-plan.html
+++ b/src/main/resources/static/docs/api-doc-plan.html
@@ -481,10 +481,10 @@ Host: localhost:8080
 
 {
   "locationName" : "위치 이름",
-  "latitude" : 15.819747623995218,
-  "longitude" : 145.98303519430863,
+  "latitude" : 10.103997450535687,
+  "longitude" : 145.12344211509264,
   "minutes" : 10,
-  "date" : "2024-06-30",
+  "date" : "2024-07-10",
   "startTime" : "09:00:00",
   "endTime" : "11:00:00",
   "keywords" : [ "키워드 이름" ]
@@ -560,7 +560,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 752
+Content-Length: 753
 
 {
   "planId" : 1,
@@ -580,8 +580,8 @@ Content-Length: 752
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 6.207163088849221,
-    "longitude" : 29.42000422259167,
+    "latitude" : 150.08345842730984,
+    "longitude" : 49.48827337139217,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",

--- a/src/test/java/com/sideproject/cafe_cok/member/presentation/MyPageControllerTest.java
+++ b/src/test/java/com/sideproject/cafe_cok/member/presentation/MyPageControllerTest.java
@@ -377,13 +377,13 @@ class MyPageControllerTest extends ControllerTest {
         MemberFeedbackRequest request = 개선의견_요청();
 
         mockMvc.perform(
-                        post("/api/myPage/add/feedback")
+                        post("/api/myPage/feedback")
                                 .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                                 .accept(MediaType.APPLICATION_JSON)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("myPage/add/feedback/success",
+                .andDo(document("myPage/feedback/success",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
-  FeedBack 엔티티에 의견을 분류할 수 있는 카테고리 컬럼을 추가
- 회원탈퇴와 개선의견 남기기 API 실행시 위 테이블에 카테고리 별로 저장할 수 있도록 로직을 수정

### 연관된 이슈
> #234
