### PR TITLE
fix(#237): 운영 시간이 없는 카페도 조회가 가능하도록 로직을 수정

### DIFF
--- a/src/main/java/com/sideproject/cafe_cok/cafe/domain/repository/CafeRepositoryImpl.java
+++ b/src/main/java/com/sideproject/cafe_cok/cafe/domain/repository/CafeRepositoryImpl.java
@@ -55,8 +55,8 @@ public class CafeRepositoryImpl implements CafeRepositoryCustom {
 
         return queryFactory
                 .select(cafe)
-                .from(operationHour)
-                .leftJoin(operationHour.cafe, cafe)
+                .from(cafe)
+                .leftJoin(cafe.operationHours, operationHour)
                 .leftJoin(cafe.cafeReviewKeywords, cafeReviewKeyword)
                 .leftJoin(cafeReviewKeyword.keyword, keyword)
                 .where(conditions)
@@ -143,7 +143,7 @@ public class CafeRepositoryImpl implements CafeRepositoryCustom {
         if(isEmpty(latitude) || isEmpty(longitude)) return null;
 
         double radiusInKm;
-        if(isEmpty(minutes)) radiusInKm = calculateRadiusInKm(MAX_RADIUS_TIME);
+        if(isEmpty(minutes) || minutes == 0) radiusInKm = calculateRadiusInKm(MAX_RADIUS_TIME);
         else radiusInKm = calculateRadiusInKm(minutes);
 
         NumberExpression<BigDecimal> radiansLatitude =


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
-  운영 시간이 없는 카페도 조회가 가능하도록 로직을 수정한다.
  - 위 메서드 (findNotMismatchCafes) from, left join 부분 cafe엔티티를 기준으로 수정

### 연관된 이슈
> #237 
