### PR TITLE
feat(#241): 기존 기능에서 추천 테마가 도입되는 API 변경

### DIFF
--- a/src/main/java/com/sideproject/cafe_cok/cafe/application/CafeService.java
+++ b/src/main/java/com/sideproject/cafe_cok/cafe/application/CafeService.java
@@ -190,16 +190,19 @@ public class CafeService {
         return new CafeSearchResponse(withinRadiusCafes);
     }
 
-    public CafeSearchResponse findCafeByKeyword(final CafeFindCategoryRequest request, final Long memberId) {
+    public CafeSearchResponse findCafeByKeyword(final CafeFindCategoryRequest request,
+                                                final Long memberId) {
 
         List<CafeDto> withinRadiusCafes = getWithinRadiusCafeDtoList(request.getLatitude(), request.getLongitude(), memberId);
-        List<String> targetKeywordNames = request.getKeywords();
-
+        List<String> targetKeywordNames = keywordRepository.findKeywordNames(request.getKeywords());
         List<CafeDto> filteredWithinRadiusCafes = new ArrayList<>();
-        for (CafeDto withinRadiusCafe : withinRadiusCafes) {
-            List<String> findNames = keywordRepository.findNamesByCafeId(withinRadiusCafe.getId());
-            boolean allMatch = targetKeywordNames.stream().allMatch(findNames::contains);
-            if(allMatch) filteredWithinRadiusCafes.add(withinRadiusCafe);
+
+        if(!targetKeywordNames.isEmpty()) {
+            for (CafeDto withinRadiusCafe : withinRadiusCafes) {
+                List<String> findNames = keywordRepository.findNamesByCafeId(withinRadiusCafe.getId());
+                boolean allMatch = targetKeywordNames.stream().allMatch(findNames::contains);
+                if(allMatch) filteredWithinRadiusCafes.add(withinRadiusCafe);
+            }
         }
 
         return new CafeSearchResponse(filteredWithinRadiusCafes);

--- a/src/main/java/com/sideproject/cafe_cok/cafe/domain/repository/CafeRepositoryCustom.java
+++ b/src/main/java/com/sideproject/cafe_cok/cafe/domain/repository/CafeRepositoryCustom.java
@@ -11,7 +11,8 @@ import java.util.List;
 
 public interface CafeRepositoryCustom {
 
-    List<Cafe> findNotMismatchCafes(final CreatePlanRequest request);
+    List<Cafe> findNotMismatchCafes(final CreatePlanRequest request,
+                                    final List<String> keywordNames);
 
     List<Cafe> findWithinRadiusCafeList(final BigDecimal latitude,
                                         final BigDecimal longitude);

--- a/src/main/java/com/sideproject/cafe_cok/cafe/domain/repository/CafeRepositoryImpl.java
+++ b/src/main/java/com/sideproject/cafe_cok/cafe/domain/repository/CafeRepositoryImpl.java
@@ -37,7 +37,8 @@ public class CafeRepositoryImpl implements CafeRepositoryCustom {
     }
 
     @Override
-    public List<Cafe> findNotMismatchCafes(final CreatePlanRequest request) {
+    public List<Cafe> findNotMismatchCafes(final CreatePlanRequest request,
+                                           final List<String> keywordNames) {
 
         BooleanBuilder conditions = new BooleanBuilder();
 
@@ -50,7 +51,7 @@ public class CafeRepositoryImpl implements CafeRepositoryCustom {
             conditions.and(closingTimeGoe(request.getEndTime()));
         }
 
-        conditions.and(keywordNamesIn(request.getKeywords()));
+        conditions.and(keywordNamesIn(keywordNames));
         conditions.and(isWithinRadius(request.getLatitude(), request.getLongitude(), request.getMinutes()));
 
         return queryFactory

--- a/src/main/java/com/sideproject/cafe_cok/keword/domain/repository/KeywordRepositoryCustom.java
+++ b/src/main/java/com/sideproject/cafe_cok/keword/domain/repository/KeywordRepositoryCustom.java
@@ -28,4 +28,6 @@ public interface KeywordRepositoryCustom {
 
     List<KeywordCountDto> findKeywordCountDtoListByCafeIdOrderByCountDesc(final Long cafeId,
                                                                           final Pageable pageable);
+
+    List<String> findKeywordNames(final List<String> keywords);
 }

--- a/src/main/java/com/sideproject/cafe_cok/keword/domain/repository/KeywordRepositoryImpl.java
+++ b/src/main/java/com/sideproject/cafe_cok/keword/domain/repository/KeywordRepositoryImpl.java
@@ -11,6 +11,8 @@ import com.sideproject.cafe_cok.keword.dto.KeywordCountDto;
 import com.sideproject.cafe_cok.keword.dto.KeywordDto;
 import com.sideproject.cafe_cok.keword.dto.QKeywordCountDto;
 import com.sideproject.cafe_cok.keword.dto.QKeywordDto;
+import com.sideproject.cafe_cok.theme.domain.QTheme;
+import com.sideproject.cafe_cok.theme.domain.QThemeKeyword;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Pageable;
 
@@ -18,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.sideproject.cafe_cok.keword.domain.QCafeReviewKeyword.*;
+import static com.sideproject.cafe_cok.theme.domain.QTheme.*;
+import static com.sideproject.cafe_cok.theme.domain.QThemeKeyword.*;
 import static org.springframework.util.StringUtils.isEmpty;
 import static com.sideproject.cafe_cok.combination.domain.QCombinationKeyword.*;
 import static com.sideproject.cafe_cok.keword.domain.QKeyword.*;
@@ -123,6 +127,19 @@ public class KeywordRepositoryImpl implements KeywordRepositoryCustom {
                 .orderBy(keyword.id.count().desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public List<String> findKeywordNames(final List<String> keywords) {
+
+        return queryFactory
+                .select(keyword.name)
+                .from(keyword)
+                .leftJoin(themeKeyword).on(keyword.id.eq(themeKeyword.keyword.id))
+                .leftJoin(theme).on(theme.id.eq(themeKeyword.theme.id))
+                .where(theme.name.in(keywords)
+                        .or(keyword.name.in(keywords)))
                 .fetch();
     }
 

--- a/src/main/java/com/sideproject/cafe_cok/plan/application/PlanService.java
+++ b/src/main/java/com/sideproject/cafe_cok/plan/application/PlanService.java
@@ -59,10 +59,11 @@ public class PlanService {
     public CreatePlanResponse plan(final CreatePlanRequest request,
                                    final Long memberId) {
 
-        CategoryKeywordsDto categoryKeywords = new CategoryKeywordsDto(keywordRepository.findByNameIn(request.getKeywords()));
+        List<String> findKeywordNames = keywordRepository.findKeywordNames(request.getKeywords());
+        CategoryKeywordsDto categoryKeywords = new CategoryKeywordsDto(keywordRepository.findByNameIn(findKeywordNames));
         if(categoryKeywords.getPurpose().isEmpty()) throw new NoSuchPlanKeywordException();
 
-        List<Cafe> notMismatchCafes = getNotMissMatchCafes(request);
+        List<Cafe> notMismatchCafes = getNotMissMatchCafes(request, findKeywordNames);
         if(notMismatchCafes.isEmpty()) return createMisMatchPlan(request, categoryKeywords, memberId);
 
         List<Cafe> allMatchCafes = getCafesByKeywordAllMatch(notMismatchCafes, request.getKeywords());
@@ -105,9 +106,10 @@ public class PlanService {
     }
 
 
-    private List<Cafe> getNotMissMatchCafes(final CreatePlanRequest request) {
+    private List<Cafe> getNotMissMatchCafes(final CreatePlanRequest request,
+                                            final List<String> keywordNames) {
 
-        List<Cafe> notMismatchCafes = cafeRepository.findNotMismatchCafes(request);
+        List<Cafe> notMismatchCafes = cafeRepository.findNotMismatchCafes(request, keywordNames);
         Map<Cafe, Integer> walkingTimeMap = new HashMap<>();
 
         return notMismatchCafes.stream().filter(cafe -> {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- /api/cafe/find/keywords 관련 로직 변경
  - 추천 테마를 적용해서 필터링된 카페 정보를 제공할 수 있도록 수정
  - 입력한 추천 테마에 맞는 키워드이름을 반환하도록  keywordRepository의 findKeywordNames 메서드를 생성
- /api/plan 관련 로직 변경
  -  입력한 추천 테마에 맞는 키워드에 맞는 결과를 제공하도록 변경

### 연관된 이슈
> #241 
