### PR TITLE
feat(#254): 최초 로그인(회원 생성) 시 랜덤한 닉네임을 생성할 수 있는 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,8 @@ dependencies {
 
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	implementation 'org.apache.commons:commons-lang3:3.13.0'
 }
 
 ext {

--- a/src/main/java/com/sideproject/cafe_cok/auth/application/AuthService.java
+++ b/src/main/java/com/sideproject/cafe_cok/auth/application/AuthService.java
@@ -5,6 +5,7 @@ import com.sideproject.cafe_cok.auth.dto.OAuthMember;
 import com.sideproject.cafe_cok.auth.exception.InvalidRestoreMemberException;
 import com.sideproject.cafe_cok.member.domain.Feedback;
 import com.sideproject.cafe_cok.member.domain.enums.FeedbackCategory;
+import com.sideproject.cafe_cok.member.domain.enums.SocialType;
 import com.sideproject.cafe_cok.member.domain.repository.FeedbackRepository;
 import com.sideproject.cafe_cok.member.domain.repository.MemberRepository;
 import com.sideproject.cafe_cok.auth.domain.AuthToken;
@@ -20,6 +21,7 @@ import com.sideproject.cafe_cok.bookmark.domain.repository.BookmarkFolderReposit
 import com.sideproject.cafe_cok.member.domain.Member;
 import com.sideproject.cafe_cok.review.domain.Review;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -115,7 +117,10 @@ public class AuthService {
     }
 
     private Member saveMember(final OAuthMember oAuthMember) {
-        Member savedMember = memberRepository.save(oAuthMember.toMember());
+
+        String randomNickname = generateRandomNickname();
+        Member targetMember = new Member(oAuthMember.getEmail(), randomNickname, SocialType.KAKAO);
+        Member savedMember = memberRepository.save(targetMember);
         bookmarkFolderRepository
                 .save(new BookmarkFolder(
                         BASIC_FOLDER_NAME, BASIC_FOLDER_COLOR,
@@ -132,5 +137,15 @@ public class AuthService {
         }
 
         return oAuthTokenRepository.save(new OAuthToken(member, oAuthMember.getRefreshToken()));
+    }
+
+    private String generateRandomNickname() {
+
+        String randomNickname = "";
+        do {
+            randomNickname = RandomStringUtils.random(15, true, true);
+        } while (memberRepository.existsByNickname(randomNickname));
+
+        return randomNickname;
     }
 }

--- a/src/main/java/com/sideproject/cafe_cok/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/sideproject/cafe_cok/auth/client/KakaoOAuthClient.java
@@ -48,7 +48,7 @@ public class KakaoOAuthClient implements OAuthClient {
         UserInfo userInfo = parseUserInfo(payload);
 
         String refreshToken = kakaoTokenResponse.getRefreshToken();
-        return new OAuthMember(userInfo.getEmail(), userInfo.getNickname(), refreshToken);
+        return new OAuthMember(userInfo.getEmail(), refreshToken);
     }
 
     @Override

--- a/src/main/java/com/sideproject/cafe_cok/auth/dto/OAuthMember.java
+++ b/src/main/java/com/sideproject/cafe_cok/auth/dto/OAuthMember.java
@@ -8,18 +8,11 @@ import lombok.Getter;
 public class OAuthMember {
 
     private String email;
-    private String nickname;
     private String refreshToken;
 
     public OAuthMember(final String email,
-                       final String nickname,
                        final String refreshToken) {
         this.email = email;
-        this.nickname = nickname;
         this.refreshToken = refreshToken;
-    }
-
-    public Member toMember() {
-        return new Member(email, nickname, SocialType.KAKAO);
     }
 }

--- a/src/main/java/com/sideproject/cafe_cok/auth/dto/UserInfo.java
+++ b/src/main/java/com/sideproject/cafe_cok/auth/dto/UserInfo.java
@@ -6,14 +6,12 @@ import lombok.Getter;
 public class UserInfo {
 
     private String email;
-    private String nickname;
 
     private UserInfo() {
     }
 
-    public UserInfo(final String email, final String nickname) {
+    public UserInfo(final String email) {
         this.email = email;
-        this.nickname = nickname;
     }
 
 

--- a/src/main/java/com/sideproject/cafe_cok/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/sideproject/cafe_cok/member/domain/repository/MemberRepository.java
@@ -17,6 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     boolean existsByEmailAndDeletedAtIsNotNull(final String email);
 
+    boolean existsByNickname(final String nickname);
+
     default Member getById(final Long id) {
         return findById(id)
                 .orElseThrow(NoSuchMemberException::new);


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- 닉네임을 랜덤한 임의의 값으로 지정하는 로직을 추가한다.
  - 랜덤한 닉네임을 생성한다.
    - org.apache.commons:commons-lang3 라이브러리를 사용해서 닉네임을 생성한다.
    - 닉네임은 알파벳 대소문자 + 숫자를 랜덤하게 조합하여 15자리의 닉네임을 생성한다.
    - 대문자(26) + 소문자(26) + 숫자(10) 총 62개의 문자를 15자리로 만들기 때문에 62^15의 닉네임을 생성할 수 있고 이 수는 충분히 크기 때문에 중복될 가능성이 없다고 판단.
  - 해당 닉네임이 DB에 이미 존재하는지 확인하고 존재하지 않는다면 해당 닉네임으로 회원 생성을 진행한다.
  - 카카오 소셜 로그인 API에서 닉네임 항목을 사용하지 않도록 설정한다.

### 연관된 이슈
> #254 
