### PR TITLE
refactor(#256): 랜덤한 닉네임을 생성하는 방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,6 @@ dependencies {
 
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-
-	implementation 'org.apache.commons:commons-lang3:3.13.0'
 }
 
 ext {

--- a/src/main/java/com/sideproject/cafe_cok/auth/application/AuthService.java
+++ b/src/main/java/com/sideproject/cafe_cok/auth/application/AuthService.java
@@ -19,6 +19,7 @@ import com.sideproject.cafe_cok.auth.dto.response.AccessTokenResponse;
 import com.sideproject.cafe_cok.bookmark.domain.BookmarkFolder;
 import com.sideproject.cafe_cok.bookmark.domain.repository.BookmarkFolderRepository;
 import com.sideproject.cafe_cok.member.domain.Member;
+import com.sideproject.cafe_cok.nickname.application.NicknameService;
 import com.sideproject.cafe_cok.review.domain.Review;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -41,6 +42,8 @@ public class AuthService {
     private final OAuthTokenRepository oAuthTokenRepository;
     private final AuthRefreshTokenRepository authRefreshTokenRepository;
     private final BookmarkFolderRepository bookmarkFolderRepository;
+
+    private final NicknameService nicknameService;
 
     private final String BASIC_FOLDER_NAME = "기본 폴더";
     private final String BASIC_FOLDER_COLOR = "#FE8282";
@@ -118,7 +121,7 @@ public class AuthService {
 
     private Member saveMember(final OAuthMember oAuthMember) {
 
-        String randomNickname = generateRandomNickname();
+        String randomNickname = nicknameService.generateNickname();
         Member targetMember = new Member(oAuthMember.getEmail(), randomNickname, SocialType.KAKAO);
         Member savedMember = memberRepository.save(targetMember);
         bookmarkFolderRepository
@@ -137,15 +140,5 @@ public class AuthService {
         }
 
         return oAuthTokenRepository.save(new OAuthToken(member, oAuthMember.getRefreshToken()));
-    }
-
-    private String generateRandomNickname() {
-
-        String randomNickname = "";
-        do {
-            randomNickname = RandomStringUtils.random(15, true, true);
-        } while (memberRepository.existsByNickname(randomNickname));
-
-        return randomNickname;
     }
 }

--- a/src/main/java/com/sideproject/cafe_cok/nickname/application/NicknameService.java
+++ b/src/main/java/com/sideproject/cafe_cok/nickname/application/NicknameService.java
@@ -1,0 +1,43 @@
+package com.sideproject.cafe_cok.nickname.application;
+
+import com.sideproject.cafe_cok.member.domain.repository.MemberRepository;
+import com.sideproject.cafe_cok.nickname.domain.NicknameComponent;
+import com.sideproject.cafe_cok.nickname.domain.repository.NicknameComponentRepository;
+import com.sideproject.cafe_cok.nickname.enums.NicknameComponentType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NicknameService {
+
+    private final NicknameComponentRepository nicknameComponentRepository;
+    private final MemberRepository memberRepository;
+
+    public String generateNickname() {
+
+        List<NicknameComponent> allNicknameComponents = nicknameComponentRepository.findAll();
+        List<NicknameComponent> adjectives = allNicknameComponents.stream()
+                .filter(nicknameComponent -> nicknameComponent.getType().equals(NicknameComponentType.ADJECTIVE))
+                .collect(Collectors.toList());
+        List<NicknameComponent> nouns = allNicknameComponents.stream()
+                .filter(nicknameComponent -> nicknameComponent.getType().equals(NicknameComponentType.NOUN))
+                .collect(Collectors.toList());
+
+        String nickname = "";
+        do {
+
+            String adjective = adjectives.get((int) Math.random() * adjectives.size()).getValue();
+            String noun = nouns.get((int) Math.random() * nouns.size()).getValue();
+
+            nickname = adjective + " " + noun;
+        } while(memberRepository.existsByNickname(nickname));
+
+        return nickname;
+    }
+}

--- a/src/main/java/com/sideproject/cafe_cok/nickname/domain/NicknameComponent.java
+++ b/src/main/java/com/sideproject/cafe_cok/nickname/domain/NicknameComponent.java
@@ -20,6 +20,7 @@ public class NicknameComponent {
     @Column(name = "id")
     private Long id;
 
+    @Column(name = "value", unique = true)
     private String value;
 
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/com/sideproject/cafe_cok/nickname/domain/NicknameComponent.java
+++ b/src/main/java/com/sideproject/cafe_cok/nickname/domain/NicknameComponent.java
@@ -1,0 +1,34 @@
+package com.sideproject.cafe_cok.nickname.domain;
+
+
+import com.sideproject.cafe_cok.nickname.enums.NicknameComponentType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.*;
+
+@Entity
+@Getter
+@Table(name = "nickname_components")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NicknameComponent {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    private String value;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private NicknameComponentType type;
+
+    public NicknameComponent(final String value,
+                             final NicknameComponentType type) {
+        this.value = value;
+        this.type = type;
+    }
+}

--- a/src/main/java/com/sideproject/cafe_cok/nickname/domain/repository/NicknameComponentRepository.java
+++ b/src/main/java/com/sideproject/cafe_cok/nickname/domain/repository/NicknameComponentRepository.java
@@ -1,0 +1,10 @@
+package com.sideproject.cafe_cok.nickname.domain.repository;
+
+import com.sideproject.cafe_cok.nickname.domain.NicknameComponent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+public interface NicknameComponentRepository extends JpaRepository<NicknameComponent, Long> {
+
+
+}

--- a/src/main/java/com/sideproject/cafe_cok/nickname/enums/NicknameComponentType.java
+++ b/src/main/java/com/sideproject/cafe_cok/nickname/enums/NicknameComponentType.java
@@ -1,0 +1,6 @@
+package com.sideproject.cafe_cok.nickname.enums;
+
+public enum NicknameComponentType {
+
+    ADJECTIVE, NOUN
+}

--- a/src/main/resources/static/docs/api-doc-bookmark-folder.html
+++ b/src/main/resources/static/docs/api-doc-bookmark-folder.html
@@ -1237,7 +1237,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 305
+Content-Length: 303
 
 {
   "folderId" : 1,
@@ -1248,8 +1248,8 @@ Content-Length: 305
     "cafeId" : 1,
     "cafeName" : "카페 이름",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 125.88421827772045,
-    "longitude" : 17.573138680931415
+    "latitude" : 68.08518806917243,
+    "longitude" : 53.63768960794149
   } ]
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/api-doc-cafe.html
+++ b/src/main/resources/static/docs/api-doc-cafe.html
@@ -513,14 +513,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 452
+Content-Length: 450
 
 {
   "cafeId" : 1,
   "cafeName" : "카페 이름",
   "roadAddress" : "OO시 OO구 OO동",
-  "latitude" : 125.88421827772045,
-  "longitude" : 17.573138680931415,
+  "latitude" : 68.08518806917243,
+  "longitude" : 53.63768960794149,
   "starRating" : 0,
   "reviewCount" : 0,
   "originUrl" : "원본_이미지_URL",
@@ -713,7 +713,7 @@ Content-Length: 1066
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-07-24",
+    "createDate" : "2024-07-28",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1209,7 +1209,7 @@ Content-Length: 118
 <h4 id="_http_request_6">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=17.573138680931415&amp;longitude=125.88421827772045 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=53.63768960794149&amp;longitude=68.08518806917243 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1251,7 +1251,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 402
+Content-Length: 400
 
 {
   "cafes" : [ {
@@ -1259,8 +1259,8 @@ Content-Length: 402
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 125.88421827772045,
-    "longitude" : 17.573138680931415,
+    "latitude" : 68.08518806917243,
+    "longitude" : 53.63768960794149,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1364,7 +1364,7 @@ Content-Length: 402
 <h4 id="_http_request_7">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=17.573138680931415&amp;longitude=125.88421827772045 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=53.63768960794149&amp;longitude=68.08518806917243 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1406,7 +1406,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 402
+Content-Length: 400
 
 {
   "cafes" : [ {
@@ -1414,8 +1414,8 @@ Content-Length: 402
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 125.88421827772045,
-    "longitude" : 17.573138680931415,
+    "latitude" : 68.08518806917243,
+    "longitude" : 53.63768960794149,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1524,12 +1524,12 @@ Content-Length: 402
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
-Content-Length: 112
+Content-Length: 110
 Host: localhost:8080
 
 {
-  "latitude" : 17.573138680931415,
-  "longitude" : 125.88421827772045,
+  "latitude" : 53.63768960794149,
+  "longitude" : 68.08518806917243,
   "keywords" : [ "키워드 이름" ]
 }</code></pre>
 </div>
@@ -1578,7 +1578,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 402
+Content-Length: 400
 
 {
   "cafes" : [ {
@@ -1586,8 +1586,8 @@ Content-Length: 402
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 125.88421827772045,
-    "longitude" : 17.573138680931415,
+    "latitude" : 68.08518806917243,
+    "longitude" : 53.63768960794149,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1762,7 +1762,7 @@ Content-Length: 548
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-07-24",
+    "createDate" : "2024-07-28",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1938,7 +1938,7 @@ Content-Length: 508
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-07-24",
+    "createDate" : "2024-07-28",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {

--- a/src/main/resources/static/docs/api-doc-myPage.html
+++ b/src/main/resources/static/docs/api-doc-myPage.html
@@ -760,7 +760,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "7월 24일 9시 0분",
+    "visitDateTime" : "7월 28일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -899,7 +899,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "7월 24일 9시 0분",
+    "visitDateTime" : "7월 28일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1022,14 +1022,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 1107
+Content-Length: 1103
 
 {
   "planId" : 1,
   "matchType" : "SIMILAR",
   "locationName" : "위치 이름",
   "minutes" : 10,
-  "visitDateTime" : "7월 24일 9시 0분",
+  "visitDateTime" : "7월 28일 9시 0분",
   "categoryKeywords" : {
     "purpose" : [ "키워드 이름" ],
     "menu" : [ ],
@@ -1042,8 +1042,8 @@ Content-Length: 1107
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 125.88421827772045,
-    "longitude" : 17.573138680931415,
+    "latitude" : 68.08518806917243,
+    "longitude" : 53.63768960794149,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1057,8 +1057,8 @@ Content-Length: 1107
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 125.88421827772045,
-    "longitude" : 17.573138680931415,
+    "latitude" : 68.08518806917243,
+    "longitude" : 53.63768960794149,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1462,7 +1462,7 @@ Content-Length: 464
     "starRating" : 5,
     "content" : "리뷰 내용",
     "specialNote" : "리뷰 특이사항",
-    "createdDate" : "2024-07-24",
+    "createdDate" : "2024-07-28",
     "imageUrls" : [ {
       "originUrl" : "원본_이미지_URL",
       "thumbnailUrl" : "썸네일_이미지_URL"
@@ -1741,7 +1741,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "7월 24일 9시 0분",
+    "visitDateTime" : "7월 28일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1866,7 +1866,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "7월 24일 9시 0분",
+    "visitDateTime" : "7월 28일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>

--- a/src/main/resources/static/docs/api-doc-plan.html
+++ b/src/main/resources/static/docs/api-doc-plan.html
@@ -476,15 +476,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 Content-Type: application/json
 Authorization: Bearer JWT TOKEN
 Accept: application/json
-Content-Length: 242
+Content-Length: 243
 Host: localhost:8080
 
 {
   "locationName" : "위치 이름",
-  "latitude" : 45.4088927108008,
-  "longitude" : 14.92837611063823,
+  "latitude" : 8.794139664824224,
+  "longitude" : 57.53364434022758,
   "minutes" : 10,
-  "date" : "2024-07-24",
+  "date" : "2024-07-28",
   "startTime" : "09:00:00",
   "endTime" : "11:00:00",
   "keywords" : [ "키워드 이름" ]
@@ -560,7 +560,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 754
+Content-Length: 752
 
 {
   "planId" : 1,
@@ -580,8 +580,8 @@ Content-Length: 754
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 125.88421827772045,
-    "longitude" : 17.573138680931415,
+    "latitude" : 68.08518806917243,
+    "longitude" : 53.63768960794149,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",

--- a/src/main/resources/static/docs/api-docs.html
+++ b/src/main/resources/static/docs/api-docs.html
@@ -488,7 +488,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-07-24 15:41:03 +0900
+Last updated 2024-07-24 19:58:14 +0900
 </div>
 </div>
 </body>


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- 닉네임에 사용되는 형용사와 명사를 저장할 수 있는 엔티티(테이블)를 생성한다.
  - 관리자 페이지를 통해서 관리자가 형용사와 명사를 수정/추가/삭제를 유연하게 할 수 있도록 하려면 별도의 테이블이 있는것이 더 좋을 것 같다고 판단하에 결정
- 생성된 엔티티(테이블)에 있는 값으로 랜덤한 닉네임을 생성할 수 있도록 구현한다.
  - 생성 후 이미 존재하는 닉네임인지 확인하고 존재한다면 재생성해서 할당한다.
  - 형용사와 명사가 각각 100개이므로 총 10,000개의 닉네임이 생성 가능하며 현재 서비스의 상태로는 이것으로 충분하다 판단하여 진행
  - 추후 더 많은 닉네임이 필요할 경우  명사와 형용사를 추가하거나 혹은 추가 문자를 덧 붙이는 방식으로 확장할 예정

### 연관된 이슈
> #256 
