### PR TITLE
fix(#262): 어드민 페이지에서 카페 등록 시 메뉴 이미지가 저장되지 않는 문제를 해결하기 위한 수정

### DIFF
--- a/src/main/java/com/sideproject/cafe_cok/admin/application/AdminService.java
+++ b/src/main/java/com/sideproject/cafe_cok/admin/application/AdminService.java
@@ -226,13 +226,13 @@ public class AdminService {
         List<AdminMenuRequestDto> menus = request.getMenus();
         for (AdminMenuRequestDto menu : menus) {
             Menu newMenu = new Menu(menu.getName(), menu.getPrice(), savedCafe);
-            menuRepository.save(newMenu);
+            Menu savedMenu = menuRepository.save(newMenu);
 
             //메뉴 이미지 저장
             converted = convertBase64StringToFile(menu.getImage());
             originImageUrl = s3Uploader.upload(converted, MENU_ORIGIN_IMAGE_DIR);
             thumbnailImageDir = changePath(originImageUrl, MENU_ORIGIN_IMAGE_DIR, MENU_THUMBNAIL_IMAGE_DIR);
-            Image menuImage = new Image(ImageType.MENU, originImageUrl, thumbnailImageDir, savedCafe);
+            Image menuImage = new Image(ImageType.MENU, originImageUrl, thumbnailImageDir, savedCafe, savedMenu);
             imageRepository.save(menuImage);
         }
 

--- a/src/main/java/com/sideproject/cafe_cok/admin/presentation/AdminController.java
+++ b/src/main/java/com/sideproject/cafe_cok/admin/presentation/AdminController.java
@@ -51,9 +51,6 @@ public class AdminController {
     public String getCafes(Model model) {
         List<AdminCafeDto> findCafes = adminService.findCafes();
         model.addAttribute("cafes", findCafes);
-
-
-
         return "page/cafe/list";
     }
 

--- a/src/main/java/com/sideproject/cafe_cok/admin/presentation/AdminRestController.java
+++ b/src/main/java/com/sideproject/cafe_cok/admin/presentation/AdminRestController.java
@@ -41,12 +41,7 @@ public class AdminRestController {
 
     @PostMapping("/cafe")
     public ResponseEntity<AdminSuccessAndRedirectResponse> saveCafe(@RequestBody AdminCafeSaveRequest request) {
-        List<AdminOperationHourDto> hours = request.getHours();
-        for (AdminOperationHourDto hour : hours) {
-            System.out.println(hour.getDay());
-            System.out.println(hour.getStartHour());
-            System.out.println(hour.getEndHour());
-        }
+        System.out.println("진입함");
         AdminSuccessAndRedirectResponse response = adminService.saveCafe(request);
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- 문제 원인
  - 메뉴 이미지 저장 시 이미지 엔티티를 생성할 때 새로 추가된 메뉴 값을 지정해 주지 않아서 해당 메뉴 id로 이미지 값을 찾지 못해 발생
- 문제 해결
  - AdminService 클래스의 saveCafe() 메서드에서 메뉴 이미지 생성 시 새로 저장된 메뉴를 할당하도록 코드 변경

### 연관된 이슈
> #262, #258 
