### PR TITLE
refactor(#264): 원본 이미지를 압축하여 저장할 수 있는 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.drewnoakes:metadata-extractor:2.18.0'
+	implementation 'org.imgscalr:imgscalr-lib:4.2'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -73,6 +75,7 @@ dependencies {
 
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 ext {

--- a/src/main/java/com/sideproject/cafe_cok/admin/presentation/AdminRestController.java
+++ b/src/main/java/com/sideproject/cafe_cok/admin/presentation/AdminRestController.java
@@ -41,7 +41,6 @@ public class AdminRestController {
 
     @PostMapping("/cafe")
     public ResponseEntity<AdminSuccessAndRedirectResponse> saveCafe(@RequestBody AdminCafeSaveRequest request) {
-        System.out.println("진입함");
         AdminSuccessAndRedirectResponse response = adminService.saveCafe(request);
         return ResponseEntity.ok(response);
     }

--- a/src/main/resources/static/docs/api-doc-bookmark-folder.html
+++ b/src/main/resources/static/docs/api-doc-bookmark-folder.html
@@ -1237,7 +1237,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 303
+Content-Length: 304
 
 {
   "folderId" : 1,
@@ -1248,8 +1248,8 @@ Content-Length: 303
     "cafeId" : 1,
     "cafeName" : "카페 이름",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 68.08518806917243,
-    "longitude" : 53.63768960794149
+    "latitude" : 88.00349407232456,
+    "longitude" : 19.002048416299065
   } ]
 }</code></pre>
 </div>

--- a/src/main/resources/static/docs/api-doc-cafe.html
+++ b/src/main/resources/static/docs/api-doc-cafe.html
@@ -513,14 +513,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 450
+Content-Length: 451
 
 {
   "cafeId" : 1,
   "cafeName" : "카페 이름",
   "roadAddress" : "OO시 OO구 OO동",
-  "latitude" : 68.08518806917243,
-  "longitude" : 53.63768960794149,
+  "latitude" : 88.00349407232456,
+  "longitude" : 19.002048416299065,
   "starRating" : 0,
   "reviewCount" : 0,
   "originUrl" : "원본_이미지_URL",
@@ -713,7 +713,7 @@ Content-Length: 1066
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-07-28",
+    "createDate" : "2024-07-29",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1209,7 +1209,7 @@ Content-Length: 118
 <h4 id="_http_request_6">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=53.63768960794149&amp;longitude=68.08518806917243 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/again?latitude=19.002048416299065&amp;longitude=88.00349407232456 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1251,7 +1251,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 400
+Content-Length: 401
 
 {
   "cafes" : [ {
@@ -1259,8 +1259,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 68.08518806917243,
-    "longitude" : 53.63768960794149,
+    "latitude" : 88.00349407232456,
+    "longitude" : 19.002048416299065,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1364,7 +1364,7 @@ Content-Length: 400
 <h4 id="_http_request_7">Http request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=53.63768960794149&amp;longitude=68.08518806917243 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/cafe/find/bar?latitude=19.002048416299065&amp;longitude=88.00349407232456 HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
@@ -1406,7 +1406,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 400
+Content-Length: 401
 
 {
   "cafes" : [ {
@@ -1414,8 +1414,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 68.08518806917243,
-    "longitude" : 53.63768960794149,
+    "latitude" : 88.00349407232456,
+    "longitude" : 19.002048416299065,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1524,12 +1524,12 @@ Content-Length: 400
 Content-Type: application/json
 Authorization: Bearer fake-token
 Accept: application/json
-Content-Length: 110
+Content-Length: 111
 Host: localhost:8080
 
 {
-  "latitude" : 53.63768960794149,
-  "longitude" : 68.08518806917243,
+  "latitude" : 19.002048416299065,
+  "longitude" : 88.00349407232456,
   "keywords" : [ "키워드 이름" ]
 }</code></pre>
 </div>
@@ -1578,7 +1578,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 400
+Content-Length: 401
 
 {
   "cafes" : [ {
@@ -1586,8 +1586,8 @@ Content-Length: 400
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 68.08518806917243,
-    "longitude" : 53.63768960794149,
+    "latitude" : 88.00349407232456,
+    "longitude" : 19.002048416299065,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1762,7 +1762,7 @@ Content-Length: 548
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-07-28",
+    "createDate" : "2024-07-29",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {
@@ -1938,7 +1938,7 @@ Content-Length: 508
     "content" : "리뷰 내용",
     "starRating" : 5,
     "specialNote" : "리뷰 특이사항",
-    "createDate" : "2024-07-28",
+    "createDate" : "2024-07-29",
     "picture" : "프로필 이미지 경로",
     "nickname" : "cafe_cok_nickname",
     "imageUrls" : [ {

--- a/src/main/resources/static/docs/api-doc-myPage.html
+++ b/src/main/resources/static/docs/api-doc-myPage.html
@@ -760,7 +760,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "7월 28일 9시 0분",
+    "visitDateTime" : "7월 29일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -899,7 +899,7 @@ Content-Length: 172
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "7월 28일 9시 0분",
+    "visitDateTime" : "7월 29일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1022,14 +1022,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 1103
+Content-Length: 1105
 
 {
   "planId" : 1,
   "matchType" : "SIMILAR",
   "locationName" : "위치 이름",
   "minutes" : 10,
-  "visitDateTime" : "7월 28일 9시 0분",
+  "visitDateTime" : "7월 29일 9시 0분",
   "categoryKeywords" : {
     "purpose" : [ "키워드 이름" ],
     "menu" : [ ],
@@ -1042,8 +1042,8 @@ Content-Length: 1103
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 68.08518806917243,
-    "longitude" : 53.63768960794149,
+    "latitude" : 88.00349407232456,
+    "longitude" : 19.002048416299065,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1057,8 +1057,8 @@ Content-Length: 1103
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 68.08518806917243,
-    "longitude" : 53.63768960794149,
+    "latitude" : 88.00349407232456,
+    "longitude" : 19.002048416299065,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",
@@ -1462,7 +1462,7 @@ Content-Length: 464
     "starRating" : 5,
     "content" : "리뷰 내용",
     "specialNote" : "리뷰 특이사항",
-    "createdDate" : "2024-07-28",
+    "createdDate" : "2024-07-29",
     "imageUrls" : [ {
       "originUrl" : "원본_이미지_URL",
       "thumbnailUrl" : "썸네일_이미지_URL"
@@ -1741,7 +1741,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "7월 28일 9시 0분",
+    "visitDateTime" : "7월 29일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>
@@ -1866,7 +1866,7 @@ Content-Length: 158
   "plans" : [ {
     "id" : 1,
     "location" : "위치 이름",
-    "visitDateTime" : "7월 28일 9시 0분",
+    "visitDateTime" : "7월 29일 9시 0분",
     "keywordName" : "키워드 이름"
   } ]
 }</code></pre>

--- a/src/main/resources/static/docs/api-doc-plan.html
+++ b/src/main/resources/static/docs/api-doc-plan.html
@@ -476,15 +476,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 Content-Type: application/json
 Authorization: Bearer JWT TOKEN
 Accept: application/json
-Content-Length: 243
+Content-Length: 244
 Host: localhost:8080
 
 {
   "locationName" : "위치 이름",
-  "latitude" : 8.794139664824224,
-  "longitude" : 57.53364434022758,
+  "latitude" : 42.58504316783947,
+  "longitude" : 40.956442513391934,
   "minutes" : 10,
-  "date" : "2024-07-28",
+  "date" : "2024-07-29",
   "startTime" : "09:00:00",
   "endTime" : "11:00:00",
   "keywords" : [ "키워드 이름" ]
@@ -560,7 +560,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 752
+Content-Length: 753
 
 {
   "planId" : 1,
@@ -580,8 +580,8 @@ Content-Length: 752
     "name" : "카페 이름",
     "phoneNumber" : "010-1234-5678",
     "roadAddress" : "OO시 OO구 OO동",
-    "latitude" : 68.08518806917243,
-    "longitude" : 53.63768960794149,
+    "latitude" : 88.00349407232456,
+    "longitude" : 19.002048416299065,
     "starRating" : 0,
     "reviewCount" : 0,
     "imageUrl" : "//카페 대표 이미지 썸네일 URL",


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x]  🏗️ 빌드는 성공했나요?
- [x]  🧹 불필요한 코드는 제거했나요?
- [x]  💭 이슈는 등록했나요? 
- [x]  🏷️ 라벨은 등록했나요?

### 작업 내용
- 해결 방안
  - 원본 이미지를 압축하여 압축된 이미지를 저장
  - 원본 이미지의 용량이 감소하므로 람다에서 썸네일을 만드는 로직이 동작할 때도 더 빠른 시간안에 업로드 될 수 있도록
- 작업 내용
  - S3Uloader 클래스의 upload() 메서드에 이미지를 압축하는 메서드 compress()를 추가
  - 작업 과정 중 불러들인 이미지가 회전되어서 들어오는 경우가 있음을 확인(모바일로 촬영한 세로 이미지)
  - 위 경우를 회전하기 위해 아래 라이브러리를 사용하여 이미지를 정방향으로 회전하는 로직을 추가하여 compressAndRotate() 함수 작성
    - 사용한 라이브러리 metadata-extractor, imgscalr-lib

### 연관된 이슈
> #264 , #258 
